### PR TITLE
Ai road halo (optional feature) - add AI magenta shadow to any road that used to be an AI road

### DIFF
--- a/build_data.js
+++ b/build_data.js
@@ -110,6 +110,7 @@ module.exports = function buildData() {
             ),
             writeEnJson(tstrings),
             writeFaIcons(faIcons),
+            writeRapidConfig(), 
             writeTnpIcons(tnpIcons)
         ];
 
@@ -670,6 +671,17 @@ function translationsToYAML(translations) {
 
     return YAML.safeDump({ en: { presets: translations }}, { sortKeys: commentFirst, lineWidth: -1 })
         .replace(/\'.*#\':/g, '#');
+}
+
+
+function writeRapidConfig() {
+    var readRapidConfig = readFileProm('data/rapid_config.yaml', 'utf8'); 
+
+    return Promise.all([readRapidConfig]).then(function(data) {
+        var config = YAML.load(data[0]); 
+
+        return writeFileProm('data/rapid_config.json', JSON.stringify(config, null, 4)); 
+    }); 
 }
 
 

--- a/css/30_highways_fb.css
+++ b/css/30_highways_fb.css
@@ -1,0 +1,6 @@
+/* wide highways */
+path.line.shadow.tag-highway.airoad:not(selected) {
+    stroke-width: 20;
+    stroke: #ff26d488; 
+    stroke-opacity: 1; 
+}

--- a/data/index.js
+++ b/data/index.js
@@ -16,12 +16,12 @@ import {
     resources as ociResources
 } from 'osm-community-index';
 
+import { rapid_config } from './rapid_config.json'
 import { dataImagery } from './imagery.json';
 import { presets } from './presets/presets.json';
 import { defaults } from './presets/defaults.json';
 import { categories } from './presets/categories.json';
 import { fields } from './presets/fields.json';
-
 import { geoArea as d3_geoArea } from 'd3-geo';
 import whichPolygon from 'which-polygon';
 
@@ -53,5 +53,7 @@ export var data = {
         defaults: defaults,
         categories: categories,
         fields: fields
-    }
+    }, 
 };
+
+export var rapid_feature_config = rapid_config; 

--- a/data/rapid_config.yaml
+++ b/data/rapid_config.yaml
@@ -1,0 +1,9 @@
+
+# Rapid configuration-  for customizing runtime behavior. 
+# The use case for this file is to enable/disable features without
+# needing to open/edit/rebuild the code. 
+rapid_config: 
+  # This setting styles any features in the map with a special shadow effect if 
+  # and only if they were originally presented to the user as AI features
+  style_fb_ai_roads:
+    enabled: false

--- a/development_server.js
+++ b/development_server.js
@@ -27,8 +27,10 @@ if (isDevelopment) {
     gaze([
             'data/**/*.{js,json}',
             'data/core.yaml',
+            'data/rapid_config.yaml',
             // ignore the output files of `buildData`
             '!data/presets/categories.json',
+            '!data/rapid_config.json', 
             '!data/presets/fields.json',
             '!data/presets/presets.json',
             '!data/presets.yaml',

--- a/modules/svg/lines.js
+++ b/modules/svg/lines.js
@@ -10,6 +10,7 @@ import { utilArrayFlatten, utilArrayGroupBy } from '../util';
 import { utilDetect } from '../util/detect';
 import _isEqual from 'lodash-es/isEqual';
 import _omit from 'lodash-es/omit';
+import { rapid_feature_config } from '../../data/';
 
 export function svgLines(projection, context) {
     var detected = utilDetect();
@@ -110,6 +111,12 @@ export function svgLines(projection, context) {
             return scoreA - scoreB;
         }
 
+        var getAIRoadStylingClass =  function(d){
+            if (!rapid_feature_config.style_fb_ai_roads.enabled) return ''; 
+
+           return (d.tags.source === 'digitalglobe' || d.tags.source === 'maxar') ? ' airoad ' : ''; 
+        };
+
         // Class for styling currently edited lines
         var tagEditClass = function(d) {
             var result = graph.entities[d.id] && base.entities[d.id] &&  !_isEqual(graph.entities[d.id].tags, base.entities[d.id].tags);
@@ -156,7 +163,7 @@ export function svgLines(projection, context) {
                     }
 
                     var oldMPClass = oldMultiPolygonOuters[d.id] ? 'old-multipolygon ' : '';
-                    return prefix + ' ' + klass + ' ' + selectedClass + oldMPClass + graphEditClass(d) + tagEditClass(d)  + d.id;
+                    return prefix + ' ' + klass + ' ' + selectedClass + oldMPClass + graphEditClass(d) + tagEditClass(d) + getAIRoadStylingClass(d) + d.id;
                 })
                 .call(svgTagClasses())
                 .merge(lines)

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -278,8 +278,9 @@ export function uiEntityEditor(context) {
 
         for (var k in changed) {
             if (!k) continue;
-            // No op for source=digitalglobe on ML roads. TODO: switch to check on __fbid__
-            if (_entityID.startsWith('w-') && k === 'source' && entity.tags.source === 'digitalglobe') continue;
+            // No op for source=digitalglobe or source=maxar on ML roads. TODO: switch to check on __fbid__
+            if (_entityID.startsWith('w-') && k === 'source' && 
+                (entity.tags.source === 'digitalglobe' || entity.tags.source === 'maxar')) continue;
             var v = changed[k];
             if (v !== undefined || tags.hasOwnProperty(k)) {
                 tags[k] = v;

--- a/modules/ui/fb_road_picker.js
+++ b/modules/ui/fb_road_picker.js
@@ -25,7 +25,7 @@ export function uiFbRoadPicker(context, keybinding) {
         var entities = context.graph().entities;
         for (var eid in entities) {
             var e = entities[eid];
-            if (eid.startsWith('w-') && e && e.tags.source === 'digitalglobe') {
+            if (eid.startsWith('w-') && e && (e.tags.source === 'digitalglobe' || e.tags.source === 'maxar')) {
                 mlRoadsCount += 1;
             }
         }

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -21,10 +21,10 @@ export function uiField(context, presetField, entity, options) {
     }, options);
 
     // Don't show the remove and revert buttons for the "Sources" field on a
-    // ML road with source=digitalglobe
+    // ML road with source=digitalglobe or source=maxar
     // TODO: switch to check on __fbid__
     if (presetField.key === 'source' && entity && entity.id.startsWith('w-') &&
-        entity.tags.source === 'digitalglobe') {
+        (entity.tags.source === 'digitalglobe' || entity.tags.source === 'maxar')) {
         options.remove = false;
         options.revert = false;
     }

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -283,9 +283,9 @@ export function uiFieldCombo(field, context) {
     function removeMultikey(d) {
         d3_event.stopPropagation();
 
-        // don't move source=digitalglobe on ML road
+        // don't move source=digitalglobe or source=maxar on ML road
         // TODO: switch to check on __fbid__
-        if (field.key === 'source' && _entity && _entity.id.startsWith('w-') && d.value === 'digitalglobe') return;
+        if (field.key === 'source' && _entity && _entity.id.startsWith('w-') && (d.value === 'digitalglobe' || d.value === 'maxar')) return;
         var t = {};
         if (isMulti) {
             t[d.key] = undefined;
@@ -453,9 +453,9 @@ export function uiFieldCombo(field, context) {
                 .on('click', removeMultikey)
                 .attr('class', 'remove')
                 .text(function(d) {
-                    // don't show 'x' on the digitalglobe label on ML road
+                    // don't show 'x' on the digitalglobe/maxar label on ML road
                     // TODO: switch to check on __fbid__
-                    return _entity && _entity.id.startsWith('w-') && field.key === 'source' && d.value === 'digitalglobe' ? '' : '×';
+                    return _entity && _entity.id.startsWith('w-') && field.key === 'source' && (d.value === 'digitalglobe' || d.value === 'maxar') ? '' : '×';
                 });
 
         } else {

--- a/modules/ui/raw_tag_editor.js
+++ b/modules/ui/raw_tag_editor.js
@@ -282,7 +282,8 @@ export function uiRawTagEditor(context) {
 
         function isReadOnly(d) {
             // Read-only for source=digitalglobe on ML roads. TODO: switch to check on __fbid__
-            if (_entityID && _entityID.indexOf('w-') === 0 && d.key === 'source' && d.value === 'digitalglobe') {
+            if (_entityID && _entityID.indexOf('w-') === 0 && d.key === 'source' 
+                && (d.value === 'digitalglobe' || d.value === 'maxar')) {
                 return true;
             }
             for (var i = 0; i < _readOnlyTags.length; i++) {


### PR DESCRIPTION
One of the features we would like in-house is the ability to see, at a glance, what roads used to be AI Roads, even after they've been added to the map & saved. 

This PR does two things: 
1) Introduces styling awareness of the 'source' tag and adds a magenta shadow to any road that has 'source=maxar' or 'source=digitalglobe'. 
2) Hinges this feature on a new 'rapid_config.yaml' that lives in the /data directory, which has an explicit 'enable: true/false' directive to govern this feature. 

The feature must be enabled in the new rapid_config.yaml before building/deploying.
![ai-road-glow](https://user-images.githubusercontent.com/1887955/64291064-4f2bd600-cf35-11e9-8dbb-75e296e35b4e.gif)
 

After speaking with @gaoxm we decided to leave the 'fail at build time' functionality as-is- if there is no rapid_config.yaml, the build will simply fail because the generated 'rapid_config.json' that we look for will be unavailable. 