### PR TITLE
 Fix issue #84: Change feature count tracking to operate across AI source types

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -430,8 +430,8 @@ en:
       description: Does this look like an accurate feature? Select this to start editing it so that you can connect, tag, and save it to OpenStreetMap. 👍
       annotation: Added a Map With AI feature.
       tooltip: Add this feature to the map to begin editing.
-      disabled: To help improve OSM data quality, we only allow {n} ML roads to be added in each mapping session. Please try to fix issues on your edits so far. You will be able to add more roads after saving.
-      disabled_flash: To help improve OSM data quality, we only allow {n} ML roads to be added in each mapping session.
+      disabled: To help improve OSM data quality, we only allow {n} AI features to be added in each mapping session. Please try to fix issues on your edits so far. You will be able to add more AI features after saving.
+      disabled_flash: To help improve OSM data quality, we only allow {n} AI Features to be added in each mapping session.
       key: A
     option_reject:
       label: Remove This Feature

--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -125,6 +125,17 @@ export function coreHistory(context) {
         },
 
 
+        countAIFeaturesAdded: function() {
+            var count = 0; 
+            for (var i = 0; i <= _index; i++) {
+                if (_stack[i].annotation && _stack[i].annotation.type === 'fb_accept_feature') {
+                    count++; 
+                }
+            }
+            return count; 
+        },
+
+
         peekAllAnnotations: function() {
             var result = [];
             for (var i = 0; i <= _index; i++) {

--- a/modules/core/history.js
+++ b/modules/core/history.js
@@ -125,17 +125,6 @@ export function coreHistory(context) {
         },
 
 
-        countAIFeaturesAdded: function() {
-            var count = 0; 
-            for (var i = 0; i <= _index; i++) {
-                if (_stack[i].annotation && _stack[i].annotation.type === 'fb_accept_feature') {
-                    count++; 
-                }
-            }
-            return count; 
-        },
-
-
         peekAllAnnotations: function() {
             var result = [];
             for (var i = 0; i <= _index; i++) {

--- a/modules/ui/fb_feature_picker.js
+++ b/modules/ui/fb_feature_picker.js
@@ -21,16 +21,9 @@ export function uiFbFeaturePicker(context, keybinding) {
         var gpxInUrl = utilStringQs(window.location.hash).gpx;
         if (gpxInUrl) return false;
 
-        var aiFeatures = context.history().peekAllAnnotations(); 
-
-        var aiFeatureCount = 0; 
-        for (var i = 0; i <= aiFeatures.length; i++) {
-            if (aiFeatures[i] && aiFeatures[i].type === 'fb_accept_feature') {
-                aiFeatureCount++; 
-            }
-        }
-        
-        return aiFeatureCount >= AI_FEATURES_LIMIT_NON_TM_MODE;
+        var annotations = context.history().peekAllAnnotations(); 
+        var aiFeatureAccepts = annotations.filter(function (a) { return a.type === 'fb_accept_feature'; });        
+        return aiFeatureAccepts.length >= AI_FEATURES_LIMIT_NON_TM_MODE;
     }
 
 

--- a/modules/ui/fb_feature_picker.js
+++ b/modules/ui/fb_feature_picker.js
@@ -13,36 +13,29 @@ import { uiRapidFirstEdit } from './rapid_first_edit_dialog';
 
 export function uiFbFeaturePicker(context, keybinding) {
     var _datum;
-    var ML_ROADS_LIMIT_NON_TM_MODE = 50;
+    var AI_FEATURES_LIMIT_NON_TM_MODE = 50;
 
 
-    function isAddRoadDisabled() {
+    function isAddFeatureDisabled() {
         // when task GPX is set in URL (TM mode), "add roads" is always enabled
         var gpxInUrl = utilStringQs(window.location.hash).gpx;
         if (gpxInUrl) return false;
 
-        var mlRoadsCount = 0;
-        var entities = context.graph().entities;
-        for (var eid in entities) {
-            var e = entities[eid];
-            if (eid.startsWith('w-') && e && (e.tags.source === 'digitalglobe' || e.tags.source === 'maxar')) {
-                mlRoadsCount += 1;
-            }
-        }
-        return mlRoadsCount >= ML_ROADS_LIMIT_NON_TM_MODE;
+        var numAiFeatures = context.history().countAIFeaturesAdded(); 
+        return numAiFeatures >= AI_FEATURES_LIMIT_NON_TM_MODE;
     }
 
 
     function onAcceptRoad() {
         if (_datum) {
-            if (isAddRoadDisabled()) {
+            if (isAddFeatureDisabled()) {
                 var flash = uiFlash()
                     .duration(4000)
                     .iconName('#iD-icon-rapid-plus-circle')
                     .iconClass('operation disabled')
                     .text(t(
                         'fb_feature_picker.option_accept.disabled_flash',
-                        {n: ML_ROADS_LIMIT_NON_TM_MODE}
+                        {n: AI_FEATURES_LIMIT_NON_TM_MODE}
                     ));
                 flash();
                 return;
@@ -204,10 +197,10 @@ export function uiFbFeaturePicker(context, keybinding) {
                 .placement('bottom')
                 .html(true)
                 .title(function() {
-                    return isAddRoadDisabled()
+                    return isAddFeatureDisabled()
                         ? uiTooltipHtml(t(
                               'fb_feature_picker.option_accept.disabled',
-                              {n: ML_ROADS_LIMIT_NON_TM_MODE}
+                              {n: AI_FEATURES_LIMIT_NON_TM_MODE}
                           ))
                         : uiTooltipHtml(
                               t('fb_feature_picker.option_accept.tooltip'),
@@ -215,7 +208,7 @@ export function uiFbFeaturePicker(context, keybinding) {
                           );
                 }),
             onClick: onAcceptRoad,
-            disabledFunction: isAddRoadDisabled
+            disabledFunction: isAddFeatureDisabled
         }, 'ai-features-accept');
 
         presetItem(bodyEnter, {

--- a/modules/ui/fb_feature_picker.js
+++ b/modules/ui/fb_feature_picker.js
@@ -21,8 +21,16 @@ export function uiFbFeaturePicker(context, keybinding) {
         var gpxInUrl = utilStringQs(window.location.hash).gpx;
         if (gpxInUrl) return false;
 
-        var numAiFeatures = context.history().countAIFeaturesAdded(); 
-        return numAiFeatures >= AI_FEATURES_LIMIT_NON_TM_MODE;
+        var aiFeatures = context.history().peekAllAnnotations(); 
+
+        var aiFeatureCount = 0; 
+        for (var i = 0; i <= aiFeatures.length; i++) {
+            if (aiFeatures[i] && aiFeatures[i].type === 'fb_accept_feature') {
+                aiFeatureCount++; 
+            }
+        }
+        
+        return aiFeatureCount >= AI_FEATURES_LIMIT_NON_TM_MODE;
     }
 
 

--- a/modules/ui/rapid_feature_toggle_dialog.js
+++ b/modules/ui/rapid_feature_toggle_dialog.js
@@ -169,7 +169,7 @@ export function uiRapidFeatureToggleDialog(context, AIFeatureToggleKey, featureT
             toggleOptionText
                 .append('div')
                 .attr('class', 'rapid-feature-license')
-                .html(options.license)
+                .html(options.license);
 
             toggleOptionText.select('p a')
                 .attr('target','_blank');


### PR DESCRIPTION
Concerning issue #84: We currently limit the number of AI roads per changeset to 50. This should really be 'AI Features per changeset', and was an omission/bug introduced by the new Buildings layer. 

This PR modifies the AI Feature maximum-count-per-changeset logic to include all AI features, not just roads.

In the future, as we add more datasets, we won't need to worry about how they are tagged to determine whether they're counted in the history- this implementation pretty much just counts how often the user clicked 'add AI feature' and keeps that in mind. 

![road_and_building_upload_limit](https://user-images.githubusercontent.com/1887955/70472356-eeb0b580-1a9c-11ea-972b-f5f6d39e8413.gif)
