### PR TITLE
Covid 19 tracker

### DIFF
--- a/css/65_data_fb_covid_19.css
+++ b/css/65_data_fb_covid_19.css
@@ -23,3 +23,11 @@
 .layer-covid-19 .hide {
     display: none;
 }
+
+
+
+g.point.safeplaces .stroke {
+    stroke: #444;
+    stroke-width: 1;
+    fill: #ff26d4;
+}

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -827,6 +827,10 @@ en:
       third_party_icons:
         description: Show Third Party Icons
         tooltip: Uncheck this box to avoid loading icons from third party sites such as Wikimedia Commons, Facebook, or Twitter.
+  safeplaces_export: 
+    title: Export GPS
+    no_changes: No GPS data is loaded
+    help: "Save your changes to your local hard drive."
   save:
     title: Save
     help: "Review your changes and upload them to OpenStreetMap, making them visible to other users."

--- a/modules/core/context.js
+++ b/modules/core/context.js
@@ -26,7 +26,7 @@ export function coreContext() {
     var dispatch = d3_dispatch('enter', 'exit', 'change');
     var context = utilRebind({}, dispatch, 'on');
     var _deferred = new Set();
-
+    
     context.version = '2.17.1';
     context.privacyVersion = '20191217';
 

--- a/modules/services/osm.js
+++ b/modules/services/osm.js
@@ -1020,8 +1020,11 @@ export default {
         }
     },
 
-
+    // Short Circuiting this because we're disabling the OSM Loading for this app use case. 
     isDataLoaded: function(loc) {
+        if (_off) {
+            return true;             
+        }
         var bbox = { minX: loc[0], minY: loc[1], maxX: loc[0], maxY: loc[1] };
         return _tileCache.rtree.collides(bbox);
     },

--- a/modules/svg/points.js
+++ b/modules/svg/points.js
@@ -97,7 +97,14 @@ export function svgPoints(projection, context) {
 
         var enter = groups.enter()
             .append('g')
-            .attr('class', function(d) { return 'node point ' + d.id; })
+            // If we have a time associated with the data, then we've loaded this as gsjson. 
+            .attr('class', function(d) {
+                    var classes = 'node point ' + d.id;
+                        if (d.tags.time) {
+                            classes += ' safeplaces'; 
+                        }
+                    return classes;
+                })
             .order();
 
         enter

--- a/modules/ui/export_safe_places_data.js
+++ b/modules/ui/export_safe_places_data.js
@@ -1,0 +1,46 @@
+import { event as d3_event } from 'd3-selection';
+import { t } from '../util/locale';
+import { uiCmd } from './cmd';
+import { osmChangeset } from '../osm';
+import { JXON } from '../util/jxon';
+import { actionDiscardTags } from '../actions';
+import { uiTooltipHtml } from './tooltipHtml';
+import { tooltip } from '../util/tooltip';
+import _isEmpty from 'lodash-es/isEmpty'; 
+
+export function uiExportSafePlacesData(context) {
+    var history = context.history();
+
+    function downloadFile(data, fileName) {
+        // Create an invisible A element
+        var a = document.createElement('a');
+        a.style.display = 'none';
+        document.body.appendChild(a);
+  
+        // Set the HREF to a Blob representation of the data to be downloaded
+        a.href = window.URL.createObjectURL(
+          new Blob([data])
+        );
+  
+        // Use download attribute to set set desired file name
+        a.setAttribute('download', fileName);
+  
+        // Trigger the download by simulating click
+        a.click();
+  
+        // Cleanup
+        window.URL.revokeObjectURL(a.href);
+        document.body.removeChild(a);
+      }
+
+
+      return function save() {
+        d3_event.preventDefault();
+        if (!context.inIntro() && history.hasChanges()) {
+            var _changeset = new osmChangeset();
+            var changes = history.changes(actionDiscardTags(history.difference()));
+            var osc = JXON.stringify(_changeset.osmChangeJXON(changes));
+            downloadFile(osc,'safeplace_gps_data.jxon');
+        }
+    }; 
+    }

--- a/modules/ui/index.js
+++ b/modules/ui/index.js
@@ -18,6 +18,7 @@ export { uiDataEditor } from './data_editor';
 export { uiDisclosure } from './disclosure';
 export { uiEditMenu } from './edit_menu';
 export { uiEntityEditor } from './entity_editor';
+export { uiExportSafePlacesData } from './export_safe_places_data'; 
 export { uiFbFeaturePicker } from './fb_feature_picker';
 export { uiFeatureInfo } from './feature_info';
 export { uiFeatureList } from './feature_list';

--- a/modules/ui/tools/export_safe_places.js
+++ b/modules/ui/tools/export_safe_places.js
@@ -1,4 +1,3 @@
-import { interpolateRgb as d3_interpolateRgb } from 'd3-interpolate';
 import { event as d3_event, select as d3_select } from 'd3-selection';
 import { t } from '../../util/locale';
 import { modeSave } from '../../modes';
@@ -6,9 +5,9 @@ import { svgIcon } from '../../svg';
 import { uiCmd } from '../cmd';
 import { uiTooltipHtml } from '../tooltipHtml';
 import { tooltip } from '../../util/tooltip';
+import { uiExportSafePlacesData} from '../export_safe_places_data'; 
 
-
-export function uiToolExportSafePlacesData(context) {
+export function uiToolExportSafePlaces(context) {
 
     var tool = {
         id: 'safeplaces_export',
@@ -37,13 +36,7 @@ export function uiToolExportSafePlacesData(context) {
 
     function safeplaces() {
         d3_event.preventDefault();
-        
-        // TODO: Need a new UI context here?
-        // TODO: fill in export logic here. 
-        // TODO: Display message to user if the data was saved.  
-        // if (!context.inIntro() && !isSaving() && history.hasChanges()) {
-        //     context.enter(modesafeplaces(context));
-        // }
+        uiExportSafePlacesData(context)(); 
     }
 
     function updateCount() {
@@ -138,3 +131,4 @@ export function uiToolExportSafePlacesData(context) {
 
     return tool;
 }
+    

--- a/modules/ui/tools/export_safe_places_data.js
+++ b/modules/ui/tools/export_safe_places_data.js
@@ -1,0 +1,140 @@
+import { interpolateRgb as d3_interpolateRgb } from 'd3-interpolate';
+import { event as d3_event, select as d3_select } from 'd3-selection';
+import { t } from '../../util/locale';
+import { modeSave } from '../../modes';
+import { svgIcon } from '../../svg';
+import { uiCmd } from '../cmd';
+import { uiTooltipHtml } from '../tooltipHtml';
+import { tooltip } from '../../util/tooltip';
+
+
+export function uiToolExportSafePlacesData(context) {
+
+    var tool = {
+        id: 'safeplaces_export',
+        label: t('safeplaces_export.title'),
+        userToggleable: false
+    };
+
+    var button = null;
+    var tooltipBehavior = tooltip()
+        .placement('bottom')
+        .html(true)
+        .title(uiTooltipHtml(t('safeplaces_export.no_changes'), key))
+        .scrollContainer(d3_select('#bar'));
+    var history = context.history();
+    var key = uiCmd('⌘S');
+    var _numChanges;
+
+    function isSaving() {
+        var mode = context.mode();
+        return mode && mode.id === 'save';
+    }
+
+    function isDisabled() {
+        return !_numChanges || isSaving();
+    }
+
+    function safeplaces() {
+        d3_event.preventDefault();
+        
+        // TODO: Need a new UI context here?
+        // TODO: fill in export logic here. 
+        // TODO: Display message to user if the data was saved.  
+        // if (!context.inIntro() && !isSaving() && history.hasChanges()) {
+        //     context.enter(modesafeplaces(context));
+        // }
+    }
+
+    function updateCount() {
+        var val = history.difference().summary().length;
+        if (val === _numChanges) return;
+        _numChanges = val;
+
+        if (tooltipBehavior) {
+            tooltipBehavior
+                .title(uiTooltipHtml(
+                    t(val > 0 ? 'safeplaces_export.help' : 'safeplaces_export.no_changes'), key)
+                );
+        }
+
+        if (button) {
+            button
+                .classed('disabled', isDisabled());
+
+            button.select('span.count')
+                .text(val);
+        }
+    }
+
+
+    tool.render = function(selection) {
+
+        button = selection
+            .selectAll('.bar-button')
+            .data([0]);
+
+        var buttonEnter = button
+            .enter()
+            .append('button')
+            .attr('class', 'safeplaces disabled bar-button')
+            .on('click', safeplaces)
+            .call(tooltipBehavior);
+
+        buttonEnter
+            .call(svgIcon('#iD-icon-save'));
+
+        buttonEnter
+            .append('span')
+            .attr('class', 'count')
+            .attr('aria-hidden', 'true')
+            .text('0');
+
+        button = buttonEnter.merge(button);
+
+        updateCount();
+    };
+
+    tool.allowed = function() {
+        return true;
+    };
+
+    tool.install = function() {
+        context.keybinding()
+            .on(key, safeplaces, true);
+
+        context.history()
+            .on('change.safeplaces_export', updateCount);
+
+        context
+            .on('enter.safeplaces_export', function() {
+                if (button) {
+                    button
+                        .classed('disabled', isDisabled());
+
+                    if (isSaving()) {
+                        button.call(tooltipBehavior.hide);
+                    }
+                }
+            });
+    };
+
+
+    tool.uninstall = function() {
+
+        _numChanges = null;
+
+        context.keybinding()
+            .off(key, true);
+
+        context.history()
+            .on('change.safeplaces_export', null);
+
+        context
+            .on('enter.safeplaces_export', null);
+
+        button = null;
+    };
+
+    return tool;
+}

--- a/modules/ui/tools/index.js
+++ b/modules/ui/tools/index.js
@@ -5,6 +5,7 @@ export * from './download_osc';
 export * from './ai_features_toggle';
 export * from './rapid_poweruser_features';
 export * from './rapid_covid_19_tracker';
+export * from './export_safe_places_data'; 
 export * from './modes';
 export * from './notes';
 export * from './operation';

--- a/modules/ui/tools/index.js
+++ b/modules/ui/tools/index.js
@@ -5,7 +5,7 @@ export * from './download_osc';
 export * from './ai_features_toggle';
 export * from './rapid_poweruser_features';
 export * from './rapid_covid_19_tracker';
-export * from './export_safe_places_data'; 
+export * from './export_safe_places'; 
 export * from './modes';
 export * from './notes';
 export * from './operation';

--- a/modules/ui/top_toolbar.js
+++ b/modules/ui/top_toolbar.js
@@ -48,7 +48,8 @@ export function uiTopToolbar(context) {
         addRecent = uiToolAddRecent(context),
         notes = uiToolNotes(context),
         undoRedo = uiToolUndoRedo(context),
-        save = uiToolSave(context),
+        // Disable the save button. We don't want it! 
+        //save = uiToolSave(context),
         downloadOsc = uiToolDownloadOsc(context),
         waySegments = uiToolWaySegments(context),
         structure = uiToolStructure(context),
@@ -133,7 +134,7 @@ export function uiTopToolbar(context) {
                 deleteTool,
                 'spacer',
                 undoRedo,
-                save
+//                save
             ];
 
         } else if (mode.id === 'add-point' || mode.id === 'add-line' || mode.id === 'add-area' ||
@@ -173,7 +174,7 @@ export function uiTopToolbar(context) {
                 notes,
                 'spacer',
                 undoRedo,
-                save
+//                save
             ];
         }
 

--- a/modules/ui/top_toolbar.js
+++ b/modules/ui/top_toolbar.js
@@ -23,6 +23,7 @@ import { uiToolStopDraw } from './tools/stop_draw';
 import { uiToolToolbox } from './tools/toolbox';
 import { uiToolAddingGeometry } from './tools/adding_geometry';
 import { uiToolPowerSupport } from './tools/power_support';
+import { uiToolExportSafePlacesData } from './tools/export_safe_places_data'; 
 
 export function uiTopToolbar(context) {
 
@@ -61,7 +62,7 @@ export function uiTopToolbar(context) {
         aiFeaturesToggle = uiToolAiFeaturesToggle(context),
         internalFeatures = rapid_feature_config.poweruser_features_dialog.enabled ? uiToolRapidPowerUserFeatures(context) : null,
         covidTracker = rapid_feature_config.covid_19_tracker.enabled ? uiToolRapidCovid19Tracker(context) : null,
-
+        exportSafePlaces = uiToolExportSafePlacesData(context); 
         /*
         deselect = uiToolSimpleButton({
             id: 'deselect',
@@ -134,6 +135,7 @@ export function uiTopToolbar(context) {
                 deleteTool,
                 'spacer',
                 undoRedo,
+                exportSafePlaces,
 //                save
             ];
 
@@ -174,6 +176,7 @@ export function uiTopToolbar(context) {
                 notes,
                 'spacer',
                 undoRedo,
+                exportSafePlaces,
 //                save
             ];
         }

--- a/modules/ui/top_toolbar.js
+++ b/modules/ui/top_toolbar.js
@@ -11,7 +11,7 @@ import { operationCircularize, operationContinue, operationDelete, operationDisc
     operationDowngrade, operationExtract, operationMerge, operationOrthogonalize,
     operationReverse, operationSplit, operationStraighten } from '../operations';
 import { rapid_feature_config } from '../../data/';
-import { uiToolAddFavorite, uiToolAddFeature, uiToolAddRecent, uiToolAiFeaturesToggle, uiToolRapidPowerUserFeatures, uiToolRapidCovid19Tracker, uiToolNotes, uiToolOperation, uiToolSave, uiToolUndoRedo, uiToolDownloadOsc } from './tools';
+import { uiToolAddFavorite, uiToolAddFeature, uiToolAddRecent, uiToolAiFeaturesToggle, uiToolRapidPowerUserFeatures, uiToolRapidCovid19Tracker, uiToolNotes, uiToolOperation, /*uiToolSave,*/ uiToolUndoRedo, uiToolDownloadOsc } from './tools';
 import { uiToolAddAddablePresets } from './tools/quick_presets_addable';
 import { uiToolAddGeneric } from './tools/quick_presets_generic';
 import { uiToolSimpleButton } from './tools/simple_button';
@@ -23,7 +23,7 @@ import { uiToolStopDraw } from './tools/stop_draw';
 import { uiToolToolbox } from './tools/toolbox';
 import { uiToolAddingGeometry } from './tools/adding_geometry';
 import { uiToolPowerSupport } from './tools/power_support';
-import { uiToolExportSafePlacesData } from './tools/export_safe_places_data'; 
+import { uiToolExportSafePlaces } from './tools/export_safe_places'; 
 
 export function uiTopToolbar(context) {
 
@@ -62,7 +62,7 @@ export function uiTopToolbar(context) {
         aiFeaturesToggle = uiToolAiFeaturesToggle(context),
         internalFeatures = rapid_feature_config.poweruser_features_dialog.enabled ? uiToolRapidPowerUserFeatures(context) : null,
         covidTracker = rapid_feature_config.covid_19_tracker.enabled ? uiToolRapidCovid19Tracker(context) : null,
-        exportSafePlaces = uiToolExportSafePlacesData(context); 
+        exportSafePlaces = uiToolExportSafePlaces(context), 
         /*
         deselect = uiToolSimpleButton({
             id: 'deselect',


### PR DESCRIPTION
UI elements! This turns off the 'save' button, and adds a new 'export safe places data' button instead. 

This button will take any/all changes on the graph and auto-download them in JXON format to the last downloads folder on the user's hard drive. 

Known bugs: It appears that the spjson points get loaded onto the map correctly, but they don't appear as changes on the graph. 