### PR TITLE
Substantially reduce the control surface presented to our users

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -494,7 +494,7 @@ button[disabled].action:hover {
     display: flex;
     flex-flow: row nowrap;
     justify-content: space-between;
-    padding: 0;
+    /* padding: 0; */
     overflow-x: auto;
     overflow-y: hidden;
     height: 100%;

--- a/css/80_app_fb_covid_19.css
+++ b/css/80_app_fb_covid_19.css
@@ -6,3 +6,20 @@
 .modal-rapid .fillL.rapid-stack > .modal-section > input.field-file {
     margin-top: 15px;
 } 
+
+#bar {
+    padding-left: 40px; 
+}
+
+div.background-pane .background-display-options,
+div.background-pane .background-offset { 
+    display:none; 
+} 
+
+ div.map-controls > div.map-control.map-data-control,
+ div.map-controls > div.map-control.map-issues-control,
+ div.map-controls > div.map-control.preferences-control,
+ div.map-controls > div.map-control.geolocate-control  {
+     display:none; 
+ }
+ 

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -86,8 +86,7 @@ en:
       first_time_tutorial: "If this is your first time here, consider taking the <a>quick-start tutorial</a>."
       thanks_have_fun: Thanks for contributing. Have fun!
       generic_welcome:
-        0: Ready to make the map even better?
-        1: What a great day for mapping.
+        0: ↑ Click here to begin
       welcome_back_user: "Welcome back, {displayName}."
       changesets: "You've contributed {changesets} changesets to OpenStreetMap so far."
       changesets_date: "You've contributed {changesets} changesets to OpenStreetMap since {joinDate}."
@@ -1293,14 +1292,14 @@ en:
     key: H
     help:
       title: Help
-      welcome: "Welcome to the RapiD editor for [OpenStreetMap](https://www.openstreetmap.org/). RapiD is an enhanced version of the [iD editor](https://github.com/openstreetmap/iD). With this editor you can update OpenStreetMap right from your web browser."
+      welcome: "Welcome to the Safe Places editor. With this editor you can update Safe Paths data points to help protect our users' privacy by redacting points that show sensitive places, such as their daily commute, place of work, and residence. Part of the [Safe Paths](http://safepaths.mit.edu/) initiative, Safe Places is an reduced-functionality version of the [RapiD editor](https://github.com/openstreetmap/iD), which is based off of the [iD editor](https://github.com/openstreetmap/iD)."
       open_data_h: "Open Data"
-      open_data: "Edits that you make on this map will be visible to everyone who uses OpenStreetMap. Your edits can be based on personal knowledge, on-the-ground surveying, or imagery collected from aerial or street level photos. Copying from commercial sources, like Google Maps, [is strictly forbidden](https://www.openstreetmap.org/copyright)."
+      open_data: "Edits that you make on this map will be visible/saveable only by you, and will not be uploaded to any third parties."
       before_start_h: "Before you start"
-      before_start: "You should be familiar with OpenStreetMap and this editor before you start editing. RapiD contains a walkthrough to teach you the basics of editing OpenStreetMap. Click \"Start the Walkthrough\" on this screen to take the tutorial - it takes only about 15 minutes."
+      before_start: "Click the Tracker in the upper right to start, pick the data you want to view/edit, and then remove any points that might need to be redacted. Shift-left-click to lasso a group of points, and hit 'delete' to remove them. When done, click the 'Export' button in the upper right of the screen, which will automatically save the data to a file in your downloads folder."
       open_source_h: "Open Source"
-      open_source: "The RapiD editor is a collaborative open source project, and you are using version {version} now. The source code is available [on GitHub](https://github.com/facebookincubator/RapiD)."
-      open_source_help: "You can help RapiD (and iD) by [translating](https://github.com/openstreetmap/iD/blob/master/CONTRIBUTING.md#translating) or [reporting bugs](https://github.com/facebookincubator/RapiD/issues)."
+      open_source: "The Safe Places editor is a collaborative open source project, and you are using version {version} now. The source code is available [on GitHub](https://github.com/facebookincubator/RapiD)."
+      open_source_help: "You can help Safe Places (and RapiD/iD) by [translating](https://github.com/openstreetmap/iD/blob/master/CONTRIBUTING.md#translating) or [reporting bugs](https://github.com/facebookincubator/RapiD/issues)."
     overview:
       title: Overview
       navigation_h: "Navigation"
@@ -1319,15 +1318,10 @@ en:
       multiselect_lasso: "Another way to select multiple features is to hold down the `{shift}` key, then press and hold down the {leftclick} left mouse button and drag the mouse to draw a selection lasso. All of the points inside the lasso area will be selected."
       undo_redo_h: "Undo & Redo"
       undo_redo: "Your edits are stored locally in your browser until you choose to save them to the OpenStreetMap server. You can undo edits by clicking the {undo} **Undo** button, and redo them by clicking the {redo} **Redo** button."
-      save_h: "Save"
-      save: "Click {save} **Save** to finish your edits and send them to OpenStreetMap. You should remember to save your work frequently!"
-      save_validation: "On the save screen, you'll have a chance to review what you've done. RapiD will also perform some basic checks for missing data and may offer helpful suggestions and warnings if something doesn't seem right."
-      upload_h: "Upload"
-      upload: "Before uploading your changes you must enter a [changeset comment](https://wiki.openstreetmap.org/wiki/Good_changeset_comments). Then click **Upload** to send your changes to OpenStreetMap, where they will be merged into the map and publicly visible to everyone."
-      backups_h: "Automatic Backups"
-      backups: "If you can't finish your edits in one sitting, for example if your computer crashes or you close the browser tab, your edits are still saved in your browser's storage. You can come back later (on the same browser and computer), and RapiD will offer to restore your work."
+      export_h: "Exporting (saving)"
+      export: "Click {Export} **Export** to finish your edits and save them to a local file."
       keyboard_h: "Keyboard Shortcuts"
-      keyboard: "You can view a list of keyboard shortcuts by pressing the `?` key."
+      keyboard: "You can view a list of keyboard shortcuts by pressing the `?` key. (Note: These contain many shortcuts that are disabled in Safe Places."
     feature_editor:
       title: Feature Editor
       intro: "The *feature editor* appears alongside the map, and allows you to see and edit all of the information for the selected feature."

--- a/modules/ui/assistant.js
+++ b/modules/ui/assistant.js
@@ -500,7 +500,7 @@ export function uiAssistant(context) {
                 return;
             }
 
-            var genericWelcomesCount = 2;
+            var genericWelcomesCount = 1;
             bodyTextArea.html(t('assistant.launch.generic_welcome.' + Math.floor(Math.random() * genericWelcomesCount)));
 
             if (!osm.authenticated()) return;

--- a/modules/ui/help.js
+++ b/modules/ui/help.js
@@ -34,9 +34,9 @@ export function uiHelp(context) {
             'navigation_h',
             'navigation_drag',
             'navigation_zoom',
-            'features_h',
-            'features',
-            'nodes_ways'
+            // 'features_h',
+            // 'features',
+            // 'nodes_ways'
         ]],
         ['editing', [
             'select_h',
@@ -47,30 +47,25 @@ export function uiHelp(context) {
             'multiselect_lasso',
             'undo_redo_h',
             'undo_redo',
-            'save_h',
-            'save',
-            'save_validation',
-            'upload_h',
-            'upload',
-            'backups_h',
-            'backups',
+            'export_h',
+            'export',
             'keyboard_h',
             'keyboard'
         ]],
-        ['feature_editor', [
-            'intro',
-            'definitions',
-            'type_h',
-            'type',
-            'type_picker',
-            'fields_h',
-            'fields_all_fields',
-            'fields_example',
-            'fields_add_field',
-            'tags_h',
-            'tags_all_tags',
-            'tags_resources'
-        ]],
+        // ['feature_editor', [
+        //     'intro',
+        //     'definitions',
+        //     'type_h',
+        //     'type',
+        //     'type_picker',
+        //     'fields_h',
+        //     'fields_all_fields',
+        //     'fields_example',
+        //     'fields_add_field',
+        //     'tags_h',
+        //     'tags_all_tags',
+        //     'tags_resources'
+        // ]],
         ['points', [
             'intro',
             'add_point_h',
@@ -82,80 +77,80 @@ export function uiHelp(context) {
             'delete_point',
             'delete_point_command'
         ]],
-        ['lines', [
-            'intro',
-            'add_line_h',
-            'add_line',
-            'add_line_draw',
-            'add_line_finish',
-            'modify_line_h',
-            'modify_line_dragnode',
-            'modify_line_addnode',
-            'connect_line_h',
-            'connect_line',
-            'connect_line_display',
-            'connect_line_drag',
-            'connect_line_tag',
-            'disconnect_line_h',
-            'disconnect_line_command',
-            'move_line_h',
-            'move_line_command',
-            'move_line_connected',
-            'delete_line_h',
-            'delete_line',
-            'delete_line_command'
-        ]],
-        ['areas', [
-            'intro',
-            'point_or_area_h',
-            'point_or_area',
-            'add_area_h',
-            'add_area_command',
-            'add_area_draw',
-            'add_area_finish',
-            'square_area_h',
-            'square_area_command',
-            'modify_area_h',
-            'modify_area_dragnode',
-            'modify_area_addnode',
-            'delete_area_h',
-            'delete_area',
-            'delete_area_command'
-        ]],
-        ['relations', [
-            'intro',
-            'edit_relation_h',
-            'edit_relation',
-            'edit_relation_add',
-            'edit_relation_delete',
-            'maintain_relation_h',
-            'maintain_relation',
-            'relation_types_h',
-            'multipolygon_h',
-            'multipolygon',
-            'multipolygon_create',
-            'multipolygon_merge',
-            'turn_restriction_h',
-            'turn_restriction',
-            'turn_restriction_field',
-            'turn_restriction_editing',
-            'route_h',
-            'route',
-            'route_add',
-            'boundary_h',
-            'boundary',
-            'boundary_add'
-        ]],
-        ['notes', [
-            'intro',
-            'add_note_h',
-            'add_note',
-            'move_note',
-            'update_note_h',
-            'update_note',
-            'save_note_h',
-            'save_note'
-        ]],
+        // ['lines', [
+        //     'intro',
+        //     'add_line_h',
+        //     'add_line',
+        //     'add_line_draw',
+        //     'add_line_finish',
+        //     'modify_line_h',
+        //     'modify_line_dragnode',
+        //     'modify_line_addnode',
+        //     'connect_line_h',
+        //     'connect_line',
+        //     'connect_line_display',
+        //     'connect_line_drag',
+        //     'connect_line_tag',
+        //     'disconnect_line_h',
+        //     'disconnect_line_command',
+        //     'move_line_h',
+        //     'move_line_command',
+        //     'move_line_connected',
+        //     'delete_line_h',
+        //     'delete_line',
+        //     'delete_line_command'
+        // ]],
+        // ['areas', [
+        //     'intro',
+        //     'point_or_area_h',
+        //     'point_or_area',
+        //     'add_area_h',
+        //     'add_area_command',
+        //     'add_area_draw',
+        //     'add_area_finish',
+        //     'square_area_h',
+        //     'square_area_command',
+        //     'modify_area_h',
+        //     'modify_area_dragnode',
+        //     'modify_area_addnode',
+        //     'delete_area_h',
+        //     'delete_area',
+        //     'delete_area_command'
+        // ]],
+        // ['relations', [
+        //     'intro',
+        //     'edit_relation_h',
+        //     'edit_relation',
+        //     'edit_relation_add',
+        //     'edit_relation_delete',
+        //     'maintain_relation_h',
+        //     'maintain_relation',
+        //     'relation_types_h',
+        //     'multipolygon_h',
+        //     'multipolygon',
+        //     'multipolygon_create',
+        //     'multipolygon_merge',
+        //     'turn_restriction_h',
+        //     'turn_restriction',
+        //     'turn_restriction_field',
+        //     'turn_restriction_editing',
+        //     'route_h',
+        //     'route',
+        //     'route_add',
+        //     'boundary_h',
+        //     'boundary',
+        //     'boundary_add'
+        // ]],
+        // ['notes', [
+        //     'intro',
+        //     'add_note_h',
+        //     'add_note',
+        //     'move_note',
+        //     'update_note_h',
+        //     'update_note',
+        //     'save_note_h',
+        //     'save_note'
+        // ]],
 
         ['imagery', [
             'intro',
@@ -166,28 +161,28 @@ export function uiHelp(context) {
             'offset',
             'offset_change'
         ]],
-        ['streetlevel', [
-            'intro',
-            'using_h',
-            'using',
-            'photos',
-            'viewer'
-        ]],
-        ['gps', [
-            'intro',
-            'survey',
-            'using_h',
-            'using',
-            'tracing',
-            'upload'
-        ]],
-        ['qa', [
-            'intro',
-            'tools_h',
-            'tools',
-            'issues_h',
-            'issues'
-        ]]
+        // ['streetlevel', [
+        //     'intro',
+        //     'using_h',
+        //     'using',
+        //     'photos',
+        //     'viewer'
+        // ]],
+        // ['gps', [
+        //     'intro',
+        //     'survey',
+        //     'using_h',
+        //     'using',
+        //     'tracing',
+        //     'upload'
+        // ]],
+        // ['qa', [
+        //     'intro',
+        //     'tools_h',
+        //     'tools',
+        //     'issues_h',
+        //     'issues'
+        // ]]
     ];
 
     var headings = {
@@ -199,9 +194,9 @@ export function uiHelp(context) {
         'help.editing.select_h': 3,
         'help.editing.multiselect_h': 3,
         'help.editing.undo_redo_h': 3,
-        'help.editing.save_h': 3,
-        'help.editing.upload_h': 3,
-        'help.editing.backups_h': 3,
+        'help.editing.export_h': 3,
+        // 'help.editing.upload_h': 3,
+        // 'help.editing.backups_h': 3,
         'help.editing.keyboard_h': 3,
         'help.feature_editor.type_h': 3,
         'help.feature_editor.fields_h': 3,
@@ -210,32 +205,32 @@ export function uiHelp(context) {
         'help.points.move_point_h': 3,
         'help.points.delete_point_h': 3,
         'help.lines.add_line_h': 3,
-        'help.lines.modify_line_h': 3,
-        'help.lines.connect_line_h': 3,
-        'help.lines.disconnect_line_h': 3,
-        'help.lines.move_line_h': 3,
-        'help.lines.delete_line_h': 3,
-        'help.areas.point_or_area_h': 3,
-        'help.areas.add_area_h': 3,
-        'help.areas.square_area_h': 3,
-        'help.areas.modify_area_h': 3,
-        'help.areas.delete_area_h': 3,
-        'help.relations.edit_relation_h': 3,
-        'help.relations.maintain_relation_h': 3,
-        'help.relations.relation_types_h': 2,
-        'help.relations.multipolygon_h': 3,
-        'help.relations.turn_restriction_h': 3,
-        'help.relations.route_h': 3,
-        'help.relations.boundary_h': 3,
-        'help.notes.add_note_h': 3,
-        'help.notes.update_note_h': 3,
-        'help.notes.save_note_h': 3,
+        // 'help.lines.modify_line_h': 3,
+        // 'help.lines.connect_line_h': 3,
+        // 'help.lines.disconnect_line_h': 3,
+        // 'help.lines.move_line_h': 3,
+        // 'help.lines.delete_line_h': 3,
+        // 'help.areas.point_or_area_h': 3,
+        // 'help.areas.add_area_h': 3,
+        // 'help.areas.square_area_h': 3,
+        // 'help.areas.modify_area_h': 3,
+        // 'help.areas.delete_area_h': 3,
+        // 'help.relations.edit_relation_h': 3,
+        // 'help.relations.maintain_relation_h': 3,
+        // 'help.relations.relation_types_h': 2,
+        // 'help.relations.multipolygon_h': 3,
+        // 'help.relations.turn_restriction_h': 3,
+        // 'help.relations.route_h': 3,
+        // 'help.relations.boundary_h': 3,
+        // 'help.notes.add_note_h': 3,
+        // 'help.notes.update_note_h': 3,
+        // 'help.notes.save_note_h': 3,
         'help.imagery.sources_h': 3,
         'help.imagery.offsets_h': 3,
-        'help.streetlevel.using_h': 3,
-        'help.gps.using_h': 3,
-        'help.qa.tools_h': 3,
-        'help.qa.issues_h': 3
+        // 'help.streetlevel.using_h': 3,
+        // 'help.gps.using_h': 3,
+        // 'help.qa.tools_h': 3,
+        // 'help.qa.issues_h': 3
     };
 
     var replacements = {
@@ -423,21 +418,21 @@ export function uiHelp(context) {
             .append('div')
             .text(t('shortcuts.title'));
 
-        var walkthrough = toc
-            .append('li')
-            .attr('class', 'walkthrough')
-            .append('a')
-            .on('click', clickWalkthrough);
+        // var walkthrough = toc
+        //     .append('li')
+        //     .attr('class', 'walkthrough')
+        //     .append('a')
+        //     .on('click', clickWalkthrough);
 
-        walkthrough
-            .append('svg')
-            .attr('class', 'logo logo-walkthrough')
-            .append('use')
-            .attr('xlink:href', '#iD-logo-walkthrough');
+        // walkthrough
+        //     .append('svg')
+        //     .attr('class', 'logo logo-walkthrough')
+        //     .append('use')
+        //     .attr('xlink:href', '#iD-logo-walkthrough');
 
-        walkthrough
-            .append('div')
-            .text(t('splash.walkthrough'));
+        // walkthrough
+        //     .append('div')
+        //     .text(t('splash.walkthrough'));
 
 
         var helpContent = content

--- a/modules/ui/init.js
+++ b/modules/ui/init.js
@@ -317,14 +317,14 @@ export function uiInit(context) {
         context.enter(modeBrowse(context));
 
         var osm = context.connection();
-        if (!_initCounter++) {
-            if (!ui.hash.startWalkthrough) {
-                if (osm.authenticated()) {
-                    context.container()
-                        .call(uiSplashRapid(context));
-                }
-            }           
-        }
+        // if (!_initCounter++) {
+        //     if (!ui.hash.startWalkthrough) {
+        //         if (osm.authenticated()) {
+        //             context.container()
+        //                 .call(uiSplashRapid(context));
+        //         }
+        //     }           
+        // }
 
         var auth = uiLoading(context).message(t('loading_auth')).blocking(true);
 

--- a/modules/ui/top_toolbar.js
+++ b/modules/ui/top_toolbar.js
@@ -111,8 +111,8 @@ export function uiTopToolbar(context) {
             })) {
 
             tools = [
-                toolbox,
-                aiFeaturesToggle,
+                // toolbox,
+                // aiFeaturesToggle,
                 covidTracker,
                 'spacer',
                 /*
@@ -121,37 +121,37 @@ export function uiTopToolbar(context) {
                 */
                 centerZoom,
                 'spacer',
-                straighten,
-                orthogonalize,
-                circularize,
-                reverse,
-                split,
-                disconnect,
-                extract,
-                merge,
-                continueTool,
+                // straighten,
+                // orthogonalize,
+                // circularize,
+                // reverse,
+                // split,
+                // disconnect,
+                // extract,
+                // merge,
+                // continueTool,
                 'spacer',
-                downgrade,
+                // downgrade,
                 deleteTool,
                 'spacer',
                 undoRedo,
                 exportSafePlaces,
-//                save
+                // save
             ];
 
         } else if (mode.id === 'add-point' || mode.id === 'add-line' || mode.id === 'add-area' ||
             mode.id === 'draw-line' || mode.id === 'draw-area') {
 
             tools = [
-                toolbox,
-                aiFeaturesToggle,
+                // toolbox,
+                // aiFeaturesToggle,
                 covidTracker,
-                addingGeometry,
+                 addingGeometry,
                 'spacer',
-                structure,
-                powerSupport,
-                'spacer',
-                waySegments,
+                // structure,
+                // powerSupport,
+                // 'spacer',
+                // waySegments,
                 'spacer',
                 repeatAdd,
                 undoRedo,
@@ -161,23 +161,23 @@ export function uiTopToolbar(context) {
         } else {
 
             tools = [
-                toolbox,
-                aiFeaturesToggle,
+                // toolbox,
+                // aiFeaturesToggle,
                 covidTracker,
                 'spacer',
                 centerZoom,
                 'spacer',
                 addFeature,
-                addAddable,
-                addGeneric,
+                // addAddable,
+                // addGeneric,
                 addFavorite,
                 addRecent,
                 'spacer',
-                notes,
-                'spacer',
+                // notes,
+                // 'spacer',
                 undoRedo,
                 exportSafePlaces,
-//                save
+                // save
             ];
         }
 


### PR DESCRIPTION
This PR basically hides ALL THE THINGS that our users won't need to do their work. 

- Hid the intro to Rapid dialog that displays to the user on their first time visiting the site.
Hid most toolbars except for 'Add Point', delete, undo/redo, the Safe Places file loader button, and the Export button. 
- Sidebar: hid the map-data, map-issues, preferences, and geolocation controls completely. Removed many options in the remaining visible controls. 
- Rewrote the Help text to be Safe-spaces specific, got rid of any help topics that were out of bounds (OSM jargon, Ways, Relations, etc. The focus is just on GPS points for now.). 


GIF sums it up: 
![safe_places_reduced_ui](https://user-images.githubusercontent.com/1887955/76924413-97e12600-68ac-11ea-84e0-011027b01fe1.gif)
