### PR TITLE
Add duplicate address validator

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1589,6 +1589,11 @@ en:
         reference: "All roads, paths, and ferry routes should connect to form a single routing network."
       highway:
         message: "{highway} is disconnected from other roads and paths"
+    duplicate_address:
+      title: "Duplicate Addresses"
+      message: "{entity1} and {entity2} contain similar addresses"
+      tip: "Find potentially duplicate addresses."
+      reference: "Addresses should not share the same housenumber, unless they differ in other attributes like floor or unit"
     fixme_tag:
       message: '{feature} has a "Fix Me" request'
       reference: 'A "fixme" tag indicates that a mapper has requested help with a feature.'

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -904,14 +904,14 @@ en:
     roads: Roads
     roads_provided_by: provided by Facebook
     roads_license: "[license](https://mapwith.ai/doc/license/MapWithAILicense.pdf)"
-    buildings: Buildings 
+    buildings: Buildings
     buildings_provided_by: provided by Microsoft
     buildings_license: "[license](https://github.com/microsoft/USBuildingFootprints/blob/master/LICENCE-DATA)"
-  rapid_poweruser_features: 
+  rapid_poweruser_features:
     top_label: "{icon} Power User Features"
     top_label_desc: for RapiD Insiders
     ai_feature_halo: AI Feature Halo
-    ai_feature_halo_desc: Enable a halo around AI features in the map 
+    ai_feature_halo_desc: Enable a halo around AI features in the map
     tagnostic_road_combine: Tag-agnostic road combine
     tagnostic_road_combine_desc: Allow the Combine operation for roads whose highway tagging differs
     tag_sources: Tag highways as DG
@@ -1593,7 +1593,9 @@ en:
       title: "Duplicate Addresses"
       message: "{entity1} and {entity2} contain similar addresses"
       tip: "Find potentially duplicate addresses."
-      reference: "Addresses should not share the same housenumber, unless they differ in other attributes like floor or unit"
+      reference:
+        text: "Addresses should not share the same housenumber unless they differ in other attributes like floor or unit. Consider merging these addresses or adding additional attributes to make them unique."
+        tags: "The duplicate address tags are listed below:"
     fixme_tag:
       message: '{feature} has a "Fix Me" request'
       reference: 'A "fixme" tag indicates that a mapper has requested help with a feature.'

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1969,9 +1969,12 @@
             },
             "duplicate_address": {
                 "title": "Duplicate Addresses",
-                "message": "{entity1} and {entity2} contain similar address elements.",
+                "message": "{entity1} and {entity2} contain similar addresses",
                 "tip": "Find potentially duplicate addresses.",
-                "reference": "Addresses should not share the same housenumber, unless they differ in other attributes like floor or unit"
+                "reference": {
+                    "text": "Addresses should not share the same housenumber unless they differ in other attributes like floor or unit. Consider merging these addresses or adding additional attributes to make them unique.",
+                    "tags": "The duplicate address tags are listed below:"
+                }
             },
             "fixme_tag": {
                 "message": "{feature} has a \"Fix Me\" request",
@@ -10522,6 +10525,13 @@
                 "description": "The city map is an overview map that describes Gothenburg. It contains general information about land, communications, hydrography, buildings, address numbers and street names, administrative division and other orientation text.",
                 "name": "Gothenburg City map"
             },
+            "gothenburg-ortho": {
+                "attribution": {
+                    "text": "© Gothenburg municipality, CC0"
+                },
+                "description": "Orthophoto for Gothenburg municipality",
+                "name": "Gothenburg Orthophoto"
+            },
             "gsi.go.jp_airphoto": {
                 "attribution": {
                     "text": "GSI Japan"
@@ -10619,6 +10629,27 @@
                 },
                 "name": "OpenPT Map (overlay)"
             },
+            "openrailwaymap": {
+                "attribution": {
+                    "text": "Rendering: OpenRailwayMap, © Map data OpenStreetMap contributors"
+                },
+                "description": "Overlay imagery showing railway infrastructure based on OpenStreetMap data",
+                "name": "OpenRailwayMap"
+            },
+            "openrailwaymap-maxspeeds": {
+                "attribution": {
+                    "text": "Rendering: OpenRailwayMap, © Map data OpenStreetMap contributors"
+                },
+                "description": "Overlay imagery showing railway speed limits based on OpenStreetMap data",
+                "name": "OpenRailwayMap Maxspeeds"
+            },
+            "openrailwaymap-signalling": {
+                "attribution": {
+                    "text": "Rendering: OpenRailwayMap, © Map data OpenStreetMap contributors"
+                },
+                "description": "Overlay imagery showing railway signals based on OpenStreetMap data",
+                "name": "OpenRailwayMap Signalling"
+            },
             "osm-gps": {
                 "attribution": {
                     "text": "© OpenStreetMap contributors"
@@ -10689,6 +10720,12 @@
                 },
                 "name": "Thunderforest Landscape"
             },
+            "tf-outdoors": {
+                "attribution": {
+                    "text": "Maps © Thunderforest, Data © OpenStreetMap contributors"
+                },
+                "name": "Thunderforest Outdoors"
+            },
             "trafikverket-baninfo": {
                 "attribution": {
                     "text": "© Trafikverket, CC0"
@@ -10730,6 +10767,12 @@
                 },
                 "description": "Swedish NVDB road network with several options for map layers",
                 "name": "Trafikverket Road Network options"
+            },
+            "wroclaw-orto2018": {
+                "attribution": {
+                    "text": "Urząd Miasta Wrocław"
+                },
+                "name": "Wrocław: Orthophotomap 2018 (aerial image)"
             }
         },
         "community": {

--- a/dist/locales/en.json
+++ b/dist/locales/en.json
@@ -1967,6 +1967,12 @@
                     "message": "{highway} is disconnected from other roads and paths"
                 }
             },
+            "duplicate_address": {
+                "title": "Duplicate Addresses",
+                "message": "{entity1} and {entity2} contain similar address elements.",
+                "tip": "Find potentially duplicate addresses.",
+                "reference": "Addresses should not share the same housenumber, unless they differ in other attributes like floor or unit"
+            },
             "fixme_tag": {
                 "message": "{feature} has a \"Fix Me\" request",
                 "reference": "A \"fixme\" tag indicates that a mapper has requested help with a feature."

--- a/modules/validations/duplicate_address.js
+++ b/modules/validations/duplicate_address.js
@@ -70,9 +70,8 @@ export function validationDuplicateAddress(context) {
     if (!hasAddress(entity)) return [];
 
     const tree = context.history().tree();
-    const extent = entity.extent(graph);
-    const searchExtent = (entity.type === 'node') ? extent.padByMeters(50) : extent;
-    const hits = tree.intersects(searchExtent, graph);
+    const extent = entity.extent(graph).padByMeters(50);
+    const hits = tree.intersects(extent, graph);
     const dupes = hits.map(hit => isDuplicate(hit, entity)).filter(Boolean);
 
     return dupes.map(dupe => {

--- a/modules/validations/duplicate_address.js
+++ b/modules/validations/duplicate_address.js
@@ -1,0 +1,132 @@
+import { t } from '../util/locale';
+import { utilArrayIntersection, utilDisplayLabel } from '../util';
+import { validationIssue } from '../core/validation';
+
+
+export function validationDuplicateAddress(context) {
+  const type = 'duplicate_address';
+
+
+  function hasAddress(entity) {
+    return Object.keys(entity.tags).some(k => /^addr:/.test(k));
+  }
+
+
+  function isDuplicate(entity1, entity2) {
+    if (entity1.id === entity2.id) return false;   // ignore self
+
+    let dupe = { entity1: entity1, entity2: entity2, tags: {} };
+    let different = false;
+
+    // if any of these tags don't match, *and both are present*, it's not a duplicate..
+    ['addr:street', 'addr:place', 'addr:block'].forEach(k => {
+      const val1 = entity1.tags[k] || '';
+      const val2 = entity2.tags[k] || '';
+      if (val1 && val2) {     // both assigned
+        if (val1 !== val2) {
+          different = true;   // values don't match
+        } else {
+          dupe.tags[k] = val1;
+        }
+      }
+    });
+    if (different) return false;
+
+    // if any of these tags don't match, *and one is present*, it's not a duplicate..
+    ['addr:door', 'addr:unit', 'addr:flats', 'addr:floor'].forEach(k => {
+      const val1 = entity1.tags[k] || '';
+      const val2 = entity2.tags[k] || '';
+      if (val1 || val2) {     // one is assigned
+        if (val1 !== val2) {
+          different = true;   // values don't match
+        } else {
+          dupe.tags[k] = val1;
+        }
+      }
+    });
+    if (different) return false;
+
+    // compare housenumbers, which may contain multiple values
+    const housenumbers1 = (entity1.tags['addr:housenumber'] || '').split(/[;,]/).filter(Boolean);
+    const housenumbers2 = (entity2.tags['addr:housenumber'] || '').split(/[;,]/).filter(Boolean);
+    if (housenumbers1.length && housenumbers2.length) {
+      const inCommon = utilArrayIntersection(housenumbers1, housenumbers2);
+      if (!inCommon.length) {
+        different = true;   // housenumbers exist and don't match
+      } else {
+        dupe.tags['addr:housenumber'] = inCommon.join(';');
+      }
+    }
+    if (different) return false;
+
+
+    // return whatever duplicate tags we found..
+    return Object.keys(dupe.tags).length ? dupe : false;
+  }
+
+
+
+  let validation = function checkDuplicateAddress(entity, graph) {
+    if (!hasAddress(entity)) return [];
+
+    const tree = context.history().tree();
+    const extent = entity.extent(graph);
+    const searchExtent = (entity.type === 'node') ? extent.padByMeters(50) : extent;
+    const hits = tree.intersects(searchExtent, graph);
+    const dupes = hits.map(hit => isDuplicate(hit, entity)).filter(Boolean);
+
+    return dupes.map(dupe => {
+      return new validationIssue({
+        type: type,
+        severity: 'warning',
+        entityIds: [ dupe.entity1.id, dupe.entity2.id ],
+
+        message: (context) => {
+          const entity1 = context.hasEntity(dupe.entity1.id);
+          const entity2 = context.hasEntity(dupe.entity2.id);
+          const entity1Display = entity1 ? utilDisplayLabel(entity1, context) : 'Entity1';
+          const entity2Display = entity2 ? utilDisplayLabel(entity2, context) : 'Entity2';
+          return t('issues.duplicate_address.message', { entity1: entity1Display, entity2: entity2Display });
+        },
+
+        reference: (selection) => {
+          const tagData = Object.keys(dupe.tags).map(k => ({ k: k, v: dupe.tags[k] }));
+
+          let enter = selection.selectAll('.issue-reference')
+            .data([0])
+            .enter();
+
+          enter
+            .append('div')
+            .attr('class', 'issue-reference')
+            .text(t('issues.duplicate_address.reference'));
+
+          let rowsEnter = enter
+            .append('table')
+            .attr('class', 'tagDiff-table')
+            .selectAll('.tagDiff-row')
+            .data(tagData)
+            .enter()
+            .append('tr')
+            .attr('class', 'tagDiff-row');
+
+          rowsEnter
+            .append('td')
+            .attr('class', 'tagDiff-cell')
+            .text(d => d.k);
+
+          rowsEnter
+            .append('td')
+            .attr('class', 'tagDiff-cell')
+            .text(d => d.v);
+        }
+
+      });
+    });
+
+  };
+
+  validation.type = type;
+
+  return validation;
+}

--- a/modules/validations/duplicate_address.js
+++ b/modules/validations/duplicate_address.js
@@ -98,7 +98,12 @@ export function validationDuplicateAddress(context) {
           enter
             .append('div')
             .attr('class', 'issue-reference')
-            .text(t('issues.duplicate_address.reference'));
+            .text(t('issues.duplicate_address.reference.text'));
+
+          enter
+            .append('div')
+            .attr('class', 'issue-reference')
+            .text(t('issues.duplicate_address.reference.tags'));
 
           let rowsEnter = enter
             .append('table')

--- a/modules/validations/index.js
+++ b/modules/validations/index.js
@@ -2,6 +2,7 @@ export { validationAlmostJunction } from './almost_junction';
 export { validationCloseNodes } from './close_nodes';
 export { validationCrossingWays } from './crossing_ways';
 export { validationDisconnectedWay } from './disconnected_way';
+export { validationDuplicateAddress } from './duplicate_address';
 export { validationFormatting } from './invalid_format';
 export { validationHelpRequest } from './help_request';
 export { validationImpossibleOneway } from './impossible_oneway';


### PR DESCRIPTION
Here's a validator for duplicate addresses that Danny Krause and I built yesterday!

The code will trigger a duplicate address warning if features within 50 meters:
* have same `addr:housenumber` (the code handles multiple values)
* have same `addr:street`, `addr:place`, `addr:block` (if present)
* unless they differ in `addr:door` `addr:unit`, `addr:flats`, `addr:floor` (if present)

(see https://wiki.openstreetmap.org/wiki/Key:addr for more info about address tags)

Users can click the ℹ️  to see the duplicate tags.  We can possibly add a fix, or at least improve guidance about what to do.

<img width="625" alt="Screenshot 2020-06-20 11 27 27" src="https://user-images.githubusercontent.com/38784/85205395-2d93b380-b2e9-11ea-82d2-53737e8035ef.png">
