### PR TITLE
Usability improvement: Show Tags Preview in Feature Picker Dialog

### DIFF
--- a/css/80_app_fb.css
+++ b/css/80_app_fb.css
@@ -124,6 +124,23 @@ button.ai-features-toggle.layer-off use {
     color: #a0a0a0;
 }
 
+.fb-road-picker .tag-bag {
+    display: flex;
+}
+
+.fb-road-picker .tag-bag .tag-entry {
+    flex: 0 1 auto;
+    display: flex;
+    border: 1px solid white;
+    border-radius: 5px;
+}
+
+.fb-road-picker .tag-key,
+.fb-road-picker .tag-value {
+    flex: 0 1 auto;
+    padding: 0px 3px 0px 3px;
+}
+
 .modal-splash.modal-rapid {
     display: flex;
     flex-direction: column;
@@ -631,3 +648,4 @@ button.rapid-view-manage-dataset-action.secondary:hover {
     margin: 4px;
     border-radius: 5px;
 }
+

--- a/css/80_app_fb.css
+++ b/css/80_app_fb.css
@@ -126,9 +126,10 @@ button.ai-features-toggle.layer-off use {
 
 .fb-road-picker .tag-bag {
     display: flex;
+    flex-wrap: wrap;
 }
 
-.fb-road-picker .tag-bag .tag-entry {
+.fb-road-picker .tag-preview .tag-entry {
     flex: 0 1 auto;
     display: flex;
     border: 1px solid white;

--- a/css/80_app_fb.css
+++ b/css/80_app_fb.css
@@ -58,12 +58,13 @@ button.ai-features-toggle.layer-off use {
 
 .fb-road-picker .picker-icon-container {
     flex: 1 0 60px;
-    padding: 10px;
+    padding: 3px;
+    height:100%;
 }
 
 .picker-icon-container svg {
     width:40px;
-    height:40px;
+    height:100%;
 }
 
 .fb-road-picker .picker-list-button {
@@ -82,10 +83,11 @@ button.ai-features-toggle.layer-off use {
     flex-flow: row wrap;
     align-items: center;
     justify-content: center;
-    padding: 20px 10px;
+    padding: 5px 5px;
     left: 60px;
     flex-basis: 200px;
     color: #e0e0e0;
+    height: 100%;
 }
 
 .fb-road-picker .tag-reference-button {
@@ -102,7 +104,7 @@ button.ai-features-toggle.layer-off use {
 }
 
 .fb-road-picker .preset-list-item {
-    margin: 15px 0;
+    margin-top: 15px;
 }
 
 .fb-road-picker .preset-list-item .preset-icon-container svg {
@@ -124,16 +126,39 @@ button.ai-features-toggle.layer-off use {
     color: #a0a0a0;
 }
 
+.reject .preset-list-button-wrap {
+    height: 32px;
+}
+
+.reject .label {
+    font-weight: lighter;
+    font-size: smaller;
+}
+
 .fb-road-picker .tag-bag {
     display: flex;
     flex-wrap: wrap;
+    padding: 2px 0px 2px; 
+}
+.fb-road-picker .tag-preview {
+    margin: 5px 5px 0px 5px;
+    background: #444;
+    border-radius: 5px;
+    border: 1px transparent;
+}
+
+.fb-road-picker .tag-heading {
+    margin-right: 5px;
+    padding-left: 3px;
 }
 
 .fb-road-picker .tag-preview .tag-entry {
     flex: 0 1 auto;
     display: flex;
-    border: 1px solid white;
+    border: 1px solid #888;
     border-radius: 5px;
+    font-size: smaller;
+    font-weight: 300;
 }
 
 .fb-road-picker .tag-key,
@@ -141,6 +166,12 @@ button.ai-features-toggle.layer-off use {
     flex: 0 1 auto;
     padding: 0px 3px 0px 3px;
 }
+
+.fb-road-picker .tag-key {
+    font-weight: bold;
+    font-size: unset;
+}
+
 
 .modal-splash.modal-rapid {
     display: flex;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -535,6 +535,8 @@ en:
   fb_feature_license: Facebook's Map With AI License
   fb_feature_picker:
     prompt: How would you like to proceed with this selected feature?
+    tags:
+      title: Tags
     option_accept:
       label: Use This Feature
       description: Does this look like an accurate feature? Select this to start editing it so that you can connect, tag, and save it to OpenStreetMap. 👍

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -536,7 +536,7 @@ en:
   fb_feature_picker:
     prompt: How would you like to proceed with this selected feature?
     tags:
-      title: Tags
+      title: 'Tags:'
     option_accept:
       label: Use This Feature
       description: Does this look like an accurate feature? Select this to start editing it so that you can connect, tag, and save it to OpenStreetMap. 👍

--- a/modules/ui/fb_feature_picker.js
+++ b/modules/ui/fb_feature_picker.js
@@ -93,10 +93,10 @@ export function uiFbFeaturePicker(context, keybinding) {
   }
 
 
-  function presetItem(selection, p, presetButtonClasses) {
+  function presetItem(selection, p, presetButtonClasses, reject) {
     let presetItem = selection
       .append('div')
-      .attr('class', 'preset-list-item');
+      .attr('class',  reject ? 'preset-list-item reject' : 'preset-list-item');
 
     let presetWrap = presetItem
       .append('div')
@@ -157,8 +157,7 @@ export function uiFbFeaturePicker(context, keybinding) {
       .append('div');
 
     tagPreview
-      .attr('class', 'tag-preview')
-      .text(t('fb_feature_picker.tags.title'));
+      .attr('class', 'tag-preview'); 
 
     var tagEntries= [];
     Object.keys(tagsObj).forEach(k => { tagEntries.push({'key':k, 'value':tagsObj[k]});});
@@ -166,6 +165,11 @@ export function uiFbFeaturePicker(context, keybinding) {
     var tagBag = tagPreview
       .append('div')
       .attr('class', 'tag-bag');
+
+    tagBag
+      .append('div')
+      .attr('class', 'tag-heading')
+      .text(t('fb_feature_picker.tags.title'));
 
 
     tagEntries.forEach(e => {
@@ -266,7 +270,9 @@ export function uiFbFeaturePicker(context, keybinding) {
         }),
       onClick: onAcceptFeature,
       disabledFunction: isAddFeatureDisabled
-    }, 'ai-features-accept');
+    }, 'ai-features-accept', false);
+
+    previewTags(bodyEnter, _datum.tags);
 
     presetItem(bodyEnter, {
       iconName: '#iD-icon-rapid-minus-circle',
@@ -280,9 +286,8 @@ export function uiFbFeaturePicker(context, keybinding) {
           t('fb_feature_picker.option_reject.key')
         )),
       onClick: onRejectFeature
-    }, 'ai-features-reject');
+    }, 'ai-features-reject', true);
 
-    previewTags(bodyEnter, _datum.tags);
 
     // Update body
     body = body

--- a/modules/ui/fb_feature_picker.js
+++ b/modules/ui/fb_feature_picker.js
@@ -9,7 +9,7 @@ import { uiFlash } from './flash';
 import { uiTooltipHtml } from './tooltipHtml';
 import { utilStringQs } from '../util';
 import { uiRapidFirstEdit } from './rapid_first_edit_dialog';
-
+import { select as d3_select, selectAll as d3_selectAll } from 'd3-selection';
 
 export function uiFbFeaturePicker(context, keybinding) {
   const AI_FEATURES_LIMIT_NON_TM_MODE = 50;
@@ -149,6 +149,56 @@ export function uiFbFeaturePicker(context, keybinding) {
   }
 
 
+  function previewTags(selection, tagsObj) {
+
+    if (!tagsObj) return;
+
+    let tagPreview = selection
+      .append('div');
+
+    tagPreview
+      .attr('class', 'tag-preview')
+      .text(t('fb_feature_picker.tags.title'));
+
+    var tagEntries= [];
+    Object.keys(tagsObj).forEach(k => { tagEntries.push({'key':k, 'value':tagsObj[k]});});
+
+    var tagBag = tagPreview
+      .append('div')
+      .attr('class', 'tag-bag');
+
+
+    tagEntries.forEach(e => {
+
+      let entryDiv = tagBag.append('div')
+        .attr('class', 'tag-entry');
+
+      entryDiv.append('div').attr('class', 'tag-key').text(e.key);
+      entryDiv.append('div').attr('class', 'tag-value').text(e.value);
+    });
+
+
+
+
+    // var listContainer = tagBag
+    //   .data(tagEntries)
+    //   .enter();
+
+    // var entry  = listContainer.append('div')
+    //   .attr('class', 'tag-entry');
+
+    // entry
+    //   .append('div')
+    //   .attr('class', 'tag-key')
+    //   .text(d => d.key);
+
+    // entry
+    //   .append('div')
+    //   .attr('class', 'tag-value')
+    //   .text(d => d.value);
+  }
+
+
   function fbFeaturePicker(selection) {
     let wrap = selection.selectAll('.fb-road-picker')
       .data([0]);
@@ -231,6 +281,8 @@ export function uiFbFeaturePicker(context, keybinding) {
         )),
       onClick: onRejectFeature
     }, 'ai-features-reject');
+
+    previewTags(bodyEnter, _datum.tags);
 
     // Update body
     body = body


### PR DESCRIPTION
One of the big bits of feedback we got from our prelim testing was that folks wanted to see the tag information on the shapes BEFORE they add them to the map. This PR does exactly that!

 Screenshot: 
![image](https://user-images.githubusercontent.com/1887955/86280668-3a968980-bbaa-11ea-891b-c8b0c8623e13.png)


The 'Remove' button has been made smaller and carries less visual weight. The tags are displayed immediately below the 'Add' button, to better signify that they are associated with the 'Add' operation.  