### PR TITLE
move logic for adding source=maxar to add_entity.js

### DIFF
--- a/modules/actions/add_entity.js
+++ b/modules/actions/add_entity.js
@@ -1,5 +1,13 @@
+import { rapidPowerUserFeaturesStorage } from '../ui/rapid_poweruser_features_storage';
+
+
 export function actionAddEntity(way) {
+    var powerUserSettings = rapidPowerUserFeaturesStorage();
+
     return function(graph) {
+        if (way.type === 'way' && way.tags.highway && powerUserSettings.featureEnabled('tagSources')) {
+            way.tags.source = 'maxar';
+        }
         return graph.replace(way);
     };
 }

--- a/modules/modes/add_line.js
+++ b/modules/modes/add_line.js
@@ -8,7 +8,7 @@ import { modeBrowse } from './browse';
 import { modeSelect } from './select';
 import { modeDrawLine } from './draw_line';
 import { osmNode, osmWay } from '../osm';
-import { rapidPowerUserFeaturesStorage } from '../ui/rapid_poweruser_features_storage';
+
 
 export function modeAddLine(context, mode) {
     mode.id = 'add-line';
@@ -50,13 +50,6 @@ export function modeAddLine(context, mode) {
     function start(loc) {
         var startGraph = context.graph();
         var node = osmNode({ loc: loc, tags: mode.defaultNodeTags || {} });
-
-        if (rapidPowerUserFeaturesStorage().featureEnabled('tagSources')) {
-            if (mode.defaultTags.highway){
-                mode.defaultTags.source = 'maxar';
-            }
-        }
-
         var way = osmWay({ tags: mode.defaultTags });
 
         context.perform(


### PR DESCRIPTION
Within add_line.js, we would need to add the same logic into all 3 functions `start` `startFromWay` and `startFromNode` to make it work for all cases of road creation. Otherwise the source tag won't be added if the new road's starting point is on an existing road.

Moving logic into add_entity.js to capture all cases in one central place.

**Test Plan**:
Tested with the case of starting a new road from an existing road or an "rest area" node, and see source tag automatically added:
![image](https://user-images.githubusercontent.com/7350578/93602853-33a13b00-f991-11ea-8735-b907bf9ecbf6.png)
![image](https://user-images.githubusercontent.com/7350578/93602916-4f0c4600-f991-11ea-9b78-37ef6195cf4d.png)

Also verified that when the feature is clicked off, the tool will stop adding the source tag.