### PR TITLE
update the URL for querying Esri building datasets

### DIFF
--- a/modules/services/fb_ai_features.js
+++ b/modules/services/fb_ai_features.js
@@ -45,9 +45,8 @@ function tileURL(dataset, extent, taskExtent) {
         qs.building_source = 'microsoft';
 
     } else {
-        qs.result_type = 'road_building_vector_xml';
-        qs.building_source = 'esri';
-        qs.esri_id = datasetID;
+        qs.result_type = 'osm_xml';
+        qs.sources = 'esri_building.' + datasetID;
     }
 
     // fb_ml_road_url: if set, get road data from this url


### PR DESCRIPTION
To use our new API using result_type=osm_xml and sources=esri_building.<esri_shape_id>.

The new API is designed to reduce the total amout of data fetching and computation on
the Map With AI backend. Esri buildings is the first dataset category supported by the
new API.

Tested with the Riverside, CA building dataset and see RapiD working correctly:

![Screen Shot 2020-10-02 at 2 57 09 PM](https://user-images.githubusercontent.com/7350578/94960260-97168700-04c0-11eb-8bf5-fc6fc7f3bb77.jpg)

Also tested that the other data layers are not affected.