### PR TITLE
Fix bug bash blocking bug - no address points showing in wireframe mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+# [1.1.0](https://github.com/facebookincubator/RapiD/releases/tag/rapid-v1.1.0)
+#### 2020-Dec-7th
+#### :trumpet: New Features!
+This release brings the new [Esri ArcGIS data sets](https://openstreetmap.maps.arcgis.com/home/group.html?id=bdf6c800b3ae453b9db239e03d7c1727#overview) to RapiD!
+
+Read the [FAQ] (https://github.com/facebookmicrosites/Open-Mapping-At-Facebook/wiki/Esri-ArcGIS-FAQ) and our engineering [blog post] (https://tech.fb.com/osm-ready-data-sets/).
+
+This release is based off of iD version 2.18.3.
+#### :trumpet: Updates
+This release fixes issue #168, which prevented users from editing certain types of ways.
+
 # [1.0.12](https://github.com/facebookincubator/RapiD/releases/tag/rapid-v1.0.12)
 #### 2020-Sept-11th
 #### :trumpet: Updates

--- a/css/65_data_fb.css
+++ b/css/65_data_fb.css
@@ -113,3 +113,8 @@
     stroke-width: 1px;
 }
 
+.ideditor .fill-wireframe  .layer-ai-features .point {
+    display : inline !important;
+}
+
+


### PR DESCRIPTION
Fix bug that prevented Esri address points from displaying in wireframe mode. Also prep release changelog for 1.1.0 release.

The bug: In wireframe mode, a rule that was hiding all points in wireframe mode. Even worse, it was marked with the `!important` directive! 

```
.ideditor .fill-wireframe .point,
.ideditor .fill-wireframe .areaicon,
.ideditor .fill-wireframe .areaicon-halo,
.ideditor .fill-wireframe path.casing,
.ideditor .fill-wireframe path.fill,
.ideditor .fill-wireframe path.oneway {
    display: none !important;
}
```

The fix was to target the ai-features layer specifically and add back the default display style of 'inline'.