### PR TITLE
fix bug with poweruser dialog

### DIFF
--- a/modules/ui/rapid_poweruser_features_dialog.js
+++ b/modules/ui/rapid_poweruser_features_dialog.js
@@ -37,7 +37,7 @@ export function uiRapidPowerUserFeaturesDialog(context) {
     return prefs(`rapid-internal-feature.${featureFlag}`) === 'true';
   }
 
-  function toggleFeature(featureFlag) {
+  function toggleFeature(_, featureFlag) {
     let enabled = prefs(`rapid-internal-feature.${featureFlag}`) === 'true';
     enabled = !enabled;
     prefs(`rapid-internal-feature.${featureFlag}`, enabled);


### PR DESCRIPTION
the poweruser dialog doesn't work, when you select an option nothing happens and the checkbox goes back to it's old state when you re-open the dialog. 

This is because the first argument to `toggleFeature` is `d3_event`, the second argument is `d`.
