### PR TITLE
Show suggestion images and viewfield icons

### DIFF
--- a/css/80_app_fb.css
+++ b/css/80_app_fb.css
@@ -267,6 +267,11 @@ button.rapid-features.layer-off use {
     font-size: unset;
 }
 
+.rapid-inspector-image {
+    width: 100%;
+    margin: 5px;
+}
+
 .rapid-inspector-choices {
     display: flex;
     flex-flow: column nowrap;

--- a/css/80_app_fb.css
+++ b/css/80_app_fb.css
@@ -272,6 +272,14 @@ button.rapid-features.layer-off use {
     margin: 5px;
 }
 
+.rapid-inspector-image-highlight {
+    border: 2px solid white;
+}
+
+.rapid-inspector-image:hover {
+    border: 2px solid white;
+}
+
 .rapid-inspector-choices {
     display: flex;
     flex-flow: column nowrap;

--- a/modules/core/rapid_context.js
+++ b/modules/core/rapid_context.js
@@ -6,7 +6,10 @@ import { utilRebind } from '../util';
 
 
 export function coreRapidContext(context) {
-  const dispatch = d3_dispatch('task_extent_set');
+  const dispatch = d3_dispatch(
+    'task_extent_set',
+    'select_suggested_image',
+    'select_suggested_viewfield');
   let _rapidContext = {};
   _rapidContext.version = '1.1.0';
   _rapidContext.showPowerUser = context.initialHashParams.poweruser === 'true';
@@ -148,6 +151,19 @@ export function coreRapidContext(context) {
     _rapidContext.sources = new Set();
   };
 
+  _rapidContext.selectSuggestedImage = (d) => {
+    _rapidContext.selectedSuggestedImage = d;
+    dispatch.call('select_suggested_image');
+  }
+
+  _rapidContext.selectSuggestedViewfield = (d) => {
+    _rapidContext.selectedSuggestedImage = d;
+    dispatch.call('select_suggested_viewfield');
+  }
+
+  _rapidContext.getSelectSuggestedImage = () => {
+    return _rapidContext.selectedSuggestedImage;
+  }
 
   return utilRebind(_rapidContext, dispatch, 'on');
 }

--- a/modules/services/fb_streetview_ai_suggestions.js
+++ b/modules/services/fb_streetview_ai_suggestions.js
@@ -207,7 +207,8 @@ function parseStreetViewImageSet(xmlEle) {
             url: img.getAttribute("url"),
             sidewalkSide: img.getAttribute("sidewalk-side"),
             lat: parseFloat(img.getAttribute("lat")),
-            lon: parseFloat(img.getAttribute('lon'))
+            lon: parseFloat(img.getAttribute('lon')),
+            ca: parseFloat(img.getAttribute('ca'))
         };
     }
     streetViewImageSet.images = images;
@@ -325,6 +326,13 @@ function parseXML(dataset, xml, callback, options) {
                 }
             }
         }
+
+        // associate suggestion context with osm entities
+        osmEntities.forEach(entity => {
+            if(entity.suggestionId && cubitorContext[entity.suggestionId]) {
+                entity.suggestionContext = cubitorContext[entity.suggestionId];
+            }
+        });
 
         callback(null, osmEntities);
     });

--- a/modules/svg/rapid_features.js
+++ b/modules/svg/rapid_features.js
@@ -250,10 +250,6 @@ export function svgRapidFeatures(projection, context, dispatch) {
       return t;
   }
 
-  function viewfieldPath() {
-      return 'M 6,9 C 8,8.4 8,8.4 10,9 L 16,-2 C 12,-5 4,-5 0,-2 z';
-  }
-
 
   function eachDataset(dataset, i, nodes) {
     const rapidContext = context.rapidContext();
@@ -380,13 +376,13 @@ export function svgRapidFeatures(projection, context, dispatch) {
 
 
   function drawViewfieldPoints(selection, viewfieldPoints) {
-    let viewfield = selection.selectAll("g.suggestionViewfieldgroup")
+    let viewfield = selection.selectAll("g.suggestionViewfieldGroup")
       .data(viewfieldPoints.length ? [0] : []);
     viewfield.exit().remove();
 
     viewfield = viewfield.enter()
       .append('g')
-      .attr('class', 'suggestionViewfieldgroup')
+      .attr('class', 'suggestionViewfieldGroup')
       .merge(viewfield);
 
     let points = viewfield
@@ -399,6 +395,8 @@ export function svgRapidFeatures(projection, context, dispatch) {
       .attr('class', d => `viewfield ${d.key}`);
 
 
+    // the circle created here needs to be aligned with
+    // viewfield path added after it.
     enter
       .append('circle')
       .attr('r', 4)
@@ -408,7 +406,7 @@ export function svgRapidFeatures(projection, context, dispatch) {
 
     enter
       .append('path')
-      .attr('d', viewfieldPath)
+      .attr('d', 'M 6,9 C 8,8.4 8,8.4 10,9 L 16,-2 C 12,-5 4,-5 0,-2 z')
       .attr('fill', VIEWFIELD_MAGENTA);
 
 

--- a/modules/ui/rapid_feature_inspector.js
+++ b/modules/ui/rapid_feature_inspector.js
@@ -29,6 +29,18 @@ export function uiRapidFeatureInspector(context, keybinding) {
   }
 
 
+  function getService(serviceName) {
+    switch(serviceName) {
+      case 'esri':
+        return services.esriData;
+      case 'fbml_streetview':
+        return services.fbStreetviewSuggestions;
+      default:
+        return services.fbMLRoads;
+    }
+  }
+
+
   function onAcceptFeature() {
     if (!_datum) return;
 
@@ -54,7 +66,7 @@ export function uiRapidFeatureInspector(context, keybinding) {
       origid: _datum.__origid__,
     };
 
-    const service = _datum.__service__ === 'esri' ? services.esriData : services.fbMLRoads;
+    const service = getService(_datum.__service__);
     const graph = service.graph(_datum.__datasetid__);
     context.perform(actionRapidAcceptFeature(_datum.id, graph), annotation);
     context.enter(modeSelect(context, [_datum.id]));
@@ -258,6 +270,29 @@ export function uiRapidFeatureInspector(context, keybinding) {
       .append('div')
       .attr('class', d => `rapid-inspector-choice rapid-inspector-choice-${d.key}`)
       .each(showChoice);
+
+    if(_datum.suggestionContext && _datum.suggestionContext.streetViewImageSet) {
+      const {images} = _datum.suggestionContext.streetViewImageSet;
+      if(images) {
+        const img = body.selectAll('.rapid-inspector-images')
+          .data([0]);
+        const imagesEnter = img
+          .enter()
+          .append('div');
+
+        imagesEnter.selectAll('.rapid-inspector-image')
+          .data(images)
+          .enter()
+          .append('div')
+          .each(showImage);
+      }
+    }
+  }
+
+
+  function showImage(d, i, nodes) {
+    const selection = d3_select(nodes[i]);
+    selection.append('img').attr('src', d.url).attr('class', 'rapid-inspector-image');
   }
 
 

--- a/modules/ui/rapid_feature_inspector.js
+++ b/modules/ui/rapid_feature_inspector.js
@@ -284,7 +284,26 @@ export function uiRapidFeatureInspector(context, keybinding) {
           .data(images)
           .enter()
           .append('div')
+          .on('mouseenter', d => {
+            const rapidContext = context.rapidContext();
+            rapidContext.selectSuggestedViewfield(d);
+          })
+          .on('mouseleave', () => {
+            const rapidContext = context.rapidContext();
+            rapidContext.selectSuggestedViewfield(null);
+          })
           .each(showImage);
+
+        context.rapidContext().on('select_suggested_image', function() {
+          const selectedImage = rapidContext.getSelectSuggestedImage();
+          if(selectedImage) {
+            body.select(`.rapid-inspector-image-${selectedImage.key}`)
+              .classed('rapid-inspector-image-highlight', true);
+          } else {
+            body.selectAll(`.rapid-inspector-image`)
+              .classed('rapid-inspector-image-highlight', false);
+          }
+        });
       }
     }
   }
@@ -292,7 +311,9 @@ export function uiRapidFeatureInspector(context, keybinding) {
 
   function showImage(d, i, nodes) {
     const selection = d3_select(nodes[i]);
-    selection.append('img').attr('src', d.url).attr('class', 'rapid-inspector-image');
+    selection.append('img').attr('src', d.url)
+      .attr('class', `rapid-inspector-image rapid-inspector-image-${d.key}`);
+
   }
 
 


### PR DESCRIPTION
When an ai-suggested sidewalk is selected, show images in Rapid left hand panel and viewfield icons on the map. 
You can also accept the suggestion or ignore it. This PR is supposed to merged with streetview_workflow branch. Later PRs will add more functionality.



https://user-images.githubusercontent.com/65986784/112527313-2c078800-8d60-11eb-92df-43e0c4a4a257.mov



