### PR TITLE
fix minor UI issue

### DIFF
--- a/modules/ui/tools/rapid_features.js
+++ b/modules/ui/tools/rapid_features.js
@@ -10,8 +10,8 @@ import { uiRapidPowerUserFeaturesDialog } from '../rapid_poweruser_features_dial
 
 export function uiToolRapidFeatures(context) {
   const toggleKeyDispatcher = d3_dispatch('ai_feature_toggle');
-  const rapidFeaturesToggleKey = uiCmd('⇧' + t('map_data.layers.ai-features.key'));
-  const datasetDialog = uiRapidFeatureToggleDialog(context, rapidFeaturesToggleKey, toggleKeyDispatcher);
+  const rapidFeaturesToggleKey = '⇧' + t('map_data.layers.ai-features.key');
+  const datasetDialog = uiRapidFeatureToggleDialog(context, uiCmd(rapidFeaturesToggleKey), toggleKeyDispatcher);
   const powerUserDialog = uiRapidPowerUserFeaturesDialog(context);
   const showPowerUser = context.rapidContext().showPowerUser;
 
@@ -21,7 +21,7 @@ export function uiToolRapidFeatures(context) {
   };
 
   context.keybinding()
-    .on(rapidFeaturesToggleKey, (d3_event) => {
+    .on(uiCmd(rapidFeaturesToggleKey), (d3_event) => {
       d3_event.preventDefault();
       d3_event.stopPropagation();
       toggleFeatures();


### PR DESCRIPTION
When you hover over the RapiD icon, this dialog shows up:

![image](https://user-images.githubusercontent.com/16009897/112699530-e9c18080-8ef0-11eb-9c57-ae925b53b9b8.png)

The fact that the shortcut separated into  <kbd>S</kbd> <kbd>h</kbd> <kbd>i</kbd> <kbd>f</kbd> <kbd>t</kbd> &nbsp;&nbsp; <kbd>+</kbd> &nbsp;&nbsp; <kbd>R</kbd> is a bug due to way `uiCmd` is called.

This PR fixes it, so it now looks like this:

![image](https://user-images.githubusercontent.com/16009897/112699637-28573b00-8ef1-11eb-83a3-93193f4fc1d2.png)

