### PR TITLE
Add duplicate way validation

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1780,6 +1780,11 @@ en:
       detached:
         message: "{feature} is too close to {feature2}"
         reference: "Separate points should not share a location."
+    duplicate_way_segments:
+      title: "Duplicate Way Segments"
+      tip: "Find way segments that are duplicated (same node endpoints)"
+      message: "Two or more segments share the same pair of nodes"
+      reference: "Redundant way segments should be merged or moved apart."
     crossing_ways:
       title: Crossings Ways
       message: "{feature} crosses {feature2}"
@@ -1994,10 +1999,14 @@ en:
         title: Ignore this issue
       merge_close_vertices:
         annotation: Merged very close points in a way.
+      merge_duplicate_way_segments:
+        annotation: Merged duplicate segments in a way.
       merge_points:
         title: Merge these points
       move_points_apart:
         title: Move these points apart
+      move_way_segments_apart:
+        title: Move these way segments apart
       move_tags:
         title: Move the tags
         annotation: Moved tags.

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2007,6 +2007,8 @@ en:
         title: Move these points apart
       move_way_segments_apart:
         title: Move these way segments apart
+      remove_way_segments:
+        title: Delete one of these way segments
       move_tags:
         title: Move the tags
         annotation: Moved tags.

--- a/modules/validations/duplicate_way_segments.js
+++ b/modules/validations/duplicate_way_segments.js
@@ -8,17 +8,21 @@ import { validationIssue, validationIssueFix } from '../core/validation';
 export function validationDuplicateWaySegments(context) {
     var type = 'duplicate_way_segments';
 
+
     var validation = function(entity, graph) {
         if (entity.type === 'way') {
             return getIssuesForWay(entity);
         }
         return [];
 
+
         function isRoutableTag(key) {
             return key === 'highway' ||
                 key === 'railway' ||
                 key === 'waterway';
         }
+
+
         function isAreaTag(key) {
             return key === 'area';
         }
@@ -31,11 +35,11 @@ export function validationDuplicateWaySegments(context) {
         return Object.keys(way.tags).some(isRoutableTag);
     }
 
+
     function adjacentNodes(node1, node2, way) {
         const nodes = graph.childNodes(way);
         return Math.abs(nodes.findIndex(node => node.id === node1.id) - nodes.findIndex(node =>  node.id === node2.id)) === 1;
     }
-
 
 
         function getIssuesForWay(way) {
@@ -50,6 +54,7 @@ export function validationDuplicateWaySegments(context) {
             }
             return issues;
         }
+
 
         function getWayIssueIfAny(node1, node2, way) {
             if (node1.id === node2.id || !hasRoutableTags(way)) {
@@ -75,6 +80,7 @@ export function validationDuplicateWaySegments(context) {
                 // We just want to know if they share 2 or more ways, which means we have duplicate way geometries.
                 if (waysWithContiguousNodes.length <= 1) return null;
             }
+
 
             return new validationIssue({
                 type: type,
@@ -105,6 +111,7 @@ export function validationDuplicateWaySegments(context) {
                 }
             });
 
+            
             function showReference(selection) {
                 var referenceText = t('issues.duplicate_way_segments.reference');
                 selection.selectAll('.issue-reference')

--- a/modules/validations/duplicate_way_segments.js
+++ b/modules/validations/duplicate_way_segments.js
@@ -5,7 +5,7 @@ import { validationIssue, validationIssueFix } from '../core/validation';
 // This validation determines whether way segments are duplicated atop one another,
 // which is impossible to detect via the tool(the geometries are stacked on top of
 // one another, so they are not visible ever).
-export function validationDuplicateWaySegments(context) {
+export function validationDuplicateWaySegments() {
     var type = 'duplicate_way_segments';
 
 
@@ -20,11 +20,6 @@ export function validationDuplicateWaySegments(context) {
             return key === 'highway' ||
                 key === 'railway' ||
                 key === 'waterway';
-        }
-
-
-        function isAreaTag(key) {
-            return key === 'area';
         }
 
 
@@ -76,7 +71,7 @@ export function validationDuplicateWaySegments(context) {
                 var remainingSharedWays = sharedWays.filter(way => hasRoutableTags(way));
 
                 //Finally, get rid of ways where the two nodes in question are not continguous (this indicates a dogleg or u-shaped road splitting off from node1 and then re-joining at node 2)
-                var waysWithContiguousNodes = remainingSharedWays.filter(way => adjacentNodes(node1, node2, way))
+                var waysWithContiguousNodes = remainingSharedWays.filter(way => adjacentNodes(node1, node2, way));
 
                 // If the nodes don't share a way, or share 1 way, that's fine!
                 // We just want to know if they share 2 or more ways, which means we have duplicate way geometries.

--- a/modules/validations/duplicate_way_segments.js
+++ b/modules/validations/duplicate_way_segments.js
@@ -1,9 +1,6 @@
-import { actionMerge } from '../actions/merge';
 import { utilDisplayLabel } from '../util';
 import { t } from '../core/localizer';
 import { validationIssue, validationIssueFix } from '../core/validation';
-import { indexOf } from 'core-js/core/array';
-import { node } from 'prop-types';
 
 // This validation determines whether way segments are duplicated atop one another,
 // which is impossible to detect via the tool(the geometries are stacked on top of
@@ -17,15 +14,21 @@ export function validationDuplicateWaySegments(context) {
         }
         return [];
 
-        function rapidIsRoutableTag(key) {
+        function isRoutableTag(key) {
             return key === 'highway' ||
                 key === 'railway' ||
                 key === 'waterway';
         }
+        function isAreaTag(key) {
+            return key === 'area';
+        }
 
 
+    // Consider a way to be routable if it is a highway, railway, or wateray.
+    // if it is an area of any kind, it is not routable.
     function hasRoutableTags(way) {
-        return Object.keys(way.tags).some(rapidIsRoutableTag);
+        if (Object.keys(way.tags).some(isAreaTag)) return false;
+        return Object.keys(way.tags).some(isRoutableTag);
     }
 
     function adjacentNodes(node1, node2, way) {
@@ -89,6 +92,10 @@ export function validationDuplicateWaySegments(context) {
                         new validationIssueFix({
                             icon: 'iD-icon-plus',
                             title: t.html('issues.fix.merge_points.title'),
+                        }),
+                        new validationIssueFix({
+                            icon: 'iD-operation-delete',
+                            title: t.html('issues.fix.remove_way_segments.title')
                         }),
                         new validationIssueFix({
                             icon: 'iD-operation-disconnect',

--- a/modules/validations/duplicate_way_segments.js
+++ b/modules/validations/duplicate_way_segments.js
@@ -31,7 +31,7 @@ export function validationDuplicateWaySegments(context) {
     // Consider a way to be routable if it is a highway, railway, or wateray.
     // if it is an area of any kind, it is not routable.
     function hasRoutableTags(way) {
-        if (Object.keys(way.tags).some(isAreaTag)) return false;
+        if (way.isArea()) return false;
         return Object.keys(way.tags).some(isRoutableTag);
     }
 
@@ -42,22 +42,24 @@ export function validationDuplicateWaySegments(context) {
     }
 
 
-        function getIssuesForWay(way) {
-            var issues = [],
-                nodes = graph.childNodes(way);
-            for (var i = 0; i < nodes.length - 1; i++) {
-                var node1 = nodes[i];
-                var node2 = nodes[i+1];
+    function getIssuesForWay(way) {
+        var issues = [];
+            if (!hasRoutableTags(way)) return issues;
 
-                var issue = getWayIssueIfAny(node1, node2, way);
-                if (issue) issues.push(issue);
-            }
-            return issues;
+        var nodes = graph.childNodes(way);
+        for (var i = 0; i < nodes.length - 1; i++) {
+            var node1 = nodes[i];
+            var node2 = nodes[i+1];
+
+            var issue = getWayIssueIfAny(node1, node2, way);
+            if (issue) issues.push(issue);
         }
+        return issues;
+    }
 
 
         function getWayIssueIfAny(node1, node2, way) {
-            if (node1.id === node2.id || !hasRoutableTags(way)) {
+            if (node1.id === node2.id ) {
                 return null;
             }
 
@@ -111,7 +113,7 @@ export function validationDuplicateWaySegments(context) {
                 }
             });
 
-            
+
             function showReference(selection) {
                 var referenceText = t('issues.duplicate_way_segments.reference');
                 selection.selectAll('.issue-reference')

--- a/modules/validations/duplicate_way_segments.js
+++ b/modules/validations/duplicate_way_segments.js
@@ -1,0 +1,118 @@
+import { actionMerge } from '../actions/merge';
+import { utilDisplayLabel } from '../util';
+import { t } from '../core/localizer';
+import { validationIssue, validationIssueFix } from '../core/validation';
+import { indexOf } from 'core-js/core/array';
+import { node } from 'prop-types';
+
+// This validation determines whether way segments are duplicated atop one another,
+// which is impossible to detect via the tool(the geometries are stacked on top of
+// one another, so they are not visible ever).
+export function validationDuplicateWaySegments(context) {
+    var type = 'duplicate_way_segments';
+
+    var validation = function(entity, graph) {
+        if (entity.type === 'way') {
+            return getIssuesForWay(entity);
+        }
+        return [];
+
+        function rapidIsRoutableTag(key) {
+            return key === 'highway' ||
+                key === 'railway' ||
+                key === 'waterway';
+        }
+
+
+    function hasRoutableTags(way) {
+        return Object.keys(way.tags).some(rapidIsRoutableTag);
+    }
+
+    function adjacentNodes(node1, node2, way) {
+        const nodes = graph.childNodes(way);
+        return Math.abs(nodes.findIndex(node => node.id === node1.id) - nodes.findIndex(node =>  node.id === node2.id)) === 1;
+    }
+
+
+
+        function getIssuesForWay(way) {
+            var issues = [],
+                nodes = graph.childNodes(way);
+            for (var i = 0; i < nodes.length - 1; i++) {
+                var node1 = nodes[i];
+                var node2 = nodes[i+1];
+
+                var issue = getWayIssueIfAny(node1, node2, way);
+                if (issue) issues.push(issue);
+            }
+            return issues;
+        }
+
+        function getWayIssueIfAny(node1, node2, way) {
+            if (node1.id === node2.id || !hasRoutableTags(way)) {
+                return null;
+            }
+
+            if (node1.loc !== node2.loc) {
+                var parentWays1 = graph.parentWays(node1);
+                var parentWays2 = new Set(graph.parentWays(node2));
+
+                var sharedWays = parentWays1.filter(function(parentWay) {
+                    return parentWays2.has(parentWay);
+                });
+
+                // Now, we want to filter out any shared ways that aren't routable.
+
+                var remainingSharedWays = sharedWays.filter(way => hasRoutableTags(way));
+
+                //Finally, get rid of ways where the two nodes in question are not continguous (this indicates a dogleg or u-shaped road splitting off from node1 and then re-joining at node 2)
+                var waysWithContiguousNodes = remainingSharedWays.filter(way => adjacentNodes(node1, node2, way))
+
+                // If the nodes don't share a way, or share 1 way, that's fine!
+                // We just want to know if they share 2 or more ways, which means we have duplicate way geometries.
+                if (waysWithContiguousNodes.length <= 1) return null;
+            }
+
+            return new validationIssue({
+                type: type,
+                subtype: 'vertices',
+                severity: 'warning',
+                message: function(context) {
+                    var entity = context.hasEntity(this.entityIds[0]);
+                    return entity ? t.html('issues.duplicate_way_segments.message', { way: utilDisplayLabel(entity, context.graph()) }) : '';
+                },
+                reference: showReference,
+                entityIds: [way.id, node1.id, node2.id],
+                loc: node1.loc,
+                dynamicFixes: function() {
+                    return [
+                        new validationIssueFix({
+                            icon: 'iD-icon-plus',
+                            title: t.html('issues.fix.merge_points.title'),
+                        }),
+                        new validationIssueFix({
+                            icon: 'iD-operation-disconnect',
+                            title: t.html('issues.fix.move_way_segments_apart.title')
+                        })
+                    ];
+                }
+            });
+
+            function showReference(selection) {
+                var referenceText = t('issues.duplicate_way_segments.reference');
+                selection.selectAll('.issue-reference')
+                    .data([0])
+                    .enter()
+                    .append('div')
+                    .attr('class', 'issue-reference')
+                    .html(referenceText);
+            }
+        }
+
+    };
+
+
+    validation.type = type;
+
+    return validation;
+}

--- a/modules/validations/index.js
+++ b/modules/validations/index.js
@@ -2,6 +2,7 @@ export { validationAlmostJunction } from './almost_junction';
 export { validationCloseNodes } from './close_nodes';
 export { validationCrossingWays } from './crossing_ways';
 export { validationDisconnectedWay } from './disconnected_way';
+export { validationDuplicateWaySegments } from './duplicate_way_segments';
 export { validationFormatting } from './invalid_format';
 export { validationHelpRequest } from './help_request';
 export { validationImpossibleOneway } from './impossible_oneway';


### PR DESCRIPTION
This check adds a duplicate way validation to RapiD, by looking for single-segment ways that share the same two endpoint locations. If such segments are found, we highlight the endpoints in a validation entry. 