### PR TITLE
Add aws_deploy npm action to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,10 @@ jobs:
     - run: npm install
     - run: npm run all
     - run: npm run test
+    - run: npm run aws_deploy
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: us-west-2
+        RAPID_S3_BUCKET_NAME: world.ai.rapid
+        NODE_VERSION: ${{ matrix.node-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: build
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, deploy_with_action ]
   pull_request:
     branches: [ main, develop ]
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:legacy": "rollup --config config/rollup.config.legacy.js",
     "build:stats": "rollup --config config/rollup.config.stats.js",
     "clean": "shx rm -f dist/*.js dist/*.map dist/*.css dist/img/*.svg",
+    "aws_deploy": "python3 scripts/aws_deploy.py",
     "dist": "npm-run-all -p dist:**",
     "dist:mapillary": "shx mkdir -p dist/mapillary-js && shx cp -R node_modules/mapillary-js/dist/* dist/mapillary-js/",
     "dist:pannellum": "shx mkdir -p dist/pannellum-streetside && shx cp -R node_modules/pannellum/build/* dist/pannellum-streetside/",

--- a/scripts/aws_deploy.py
+++ b/scripts/aws_deploy.py
@@ -73,6 +73,7 @@ def deploy():
             "cp",
             newindex,
             f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{identifier}-rapid.html",
+            "--no-progress"
         ],
         capture_output=True,
     )
@@ -90,6 +91,7 @@ def deploy():
             distdir,
             f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{distdir}",
             "--recursive",
+            "--no-progress",
         ],
         capture_output=True,
     )

--- a/scripts/aws_deploy.py
+++ b/scripts/aws_deploy.py
@@ -1,0 +1,95 @@
+import errno
+import os
+import shutil
+import subprocess
+
+"""Script to upload RapiD to S3 bucket
+Usage: python3 aws_deploy.py
+
+Assumptions:
+1) You have the aws cli installed, and it can get access to credentials
+1a) This can be anything specified here: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+1b) For github actions, you should have AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY set as secrets, with AWS_DEFAULT_REGION in the environment
+2) You have installed python 3.
+3) You are running from within the iD directory.
+4) Environment variable RAPID_S3_BUCKET_NAME is defined (default: world.ai.rapid)
+5) Environment variable NODE_VERSION is defined
+See .github/workflows/build.yml for usage there
+"""
+
+def deploy():
+    print("Calculating build hash and distdir...")
+    output = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"], capture_output=True
+    )
+    hash = output.stdout.decode("utf-8").strip()
+    print("\ngithash: " + hash)
+    identifier = f"{hash}-{os.environ['NODE_VERSION']}"
+    distdir = identifier + "-dist"
+    print("\ndistdir: " + distdir)
+    # Blow away the previous dir, if any.
+    if os.path.exists(distdir):
+        print(f"Previous distribution dir {distdir} found, removing.")
+        shutil.rmtree(distdir)
+    print("\nCreating dist folder")
+    try:
+        os.mkdir(distdir)
+    except OSError as err:
+        if err.errno == errno.EEXIST:
+            print(f"{distdir} already exists")
+        elif err.errno == errno.EACCES:
+            print(f"{distdir} permission denied")
+        raise
+    print("\nCopying dist folder")
+    subprocess.check_call(args=f"cp -a ./dist/* {distdir}", shell=True)
+    print("\nPrepping rapid.html with correct asset, css, and javascript paths")
+    index = "dist/index.html"
+    newindex = os.path.join(distdir, "index.html")
+    with open(index, "r") as input:
+        with open(newindex, "w+") as output:
+            # These directives aren't all necessary for the latest RapiD; some are useful in older versions of the index.html.
+            for s in input:
+                s = (
+                    s.replace("dist/iD.css", f"/rapid/{distdir}/iD.css")
+                    .replace("'dist/iD.js'", f"'/rapid/{distdir}/iD.js'")
+                    .replace("'iD.js'", f"'/rapid/{distdir}/iD.js'")
+                    .replace("'dist/iD.legacy.js'", f"'/rapid/{distdir}/iD.legacy.js'")
+                    .replace(
+                        "var id = iD.coreContext();",
+                        f"var id = iD.coreContext().assetPath('/rapid/{distdir}/');",
+                    )
+                    .replace(".assetPath('')", f".assetPath('/rapid/{distdir}/')")
+                    .replace("href='iD.css'", f"href='/rapid/{distdir}/iD.css'")
+                    .replace("'iD.min.js'", f"'/rapid/{distdir}/iD.min.js'")
+                    .replace("'iD.legacy.js'", f"'/rapid/{distdir}/iD.legacy.js'")
+                )
+                output.write(s)
+    print("\nCopying new " + distdir + "folder and index file to s3.")
+    subprocess.check_call(
+        (
+            [
+                "aws",
+                "s3",
+                "cp",
+                distdir,
+                f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{distdir}",
+                "--recursive",
+                "--quiet",
+            ]
+        )
+    )
+    subprocess.check_call(
+        (
+            [
+                "aws",
+                "s3",
+                "cp",
+                newindex,
+                f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{identifier}-rapid.html",
+                "--quiet",
+            ]
+        )
+    )
+
+if __name__ == "__main__":
+    deploy()

--- a/scripts/aws_deploy.py
+++ b/scripts/aws_deploy.py
@@ -65,30 +65,28 @@ def deploy():
                 )
                 output.write(s)
     print("\nCopying new " + distdir + "folder and index file to s3.")
-    subprocess.check_call(
-        (
-            [
-                "aws",
-                "s3",
-                "cp",
-                distdir,
-                f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{distdir}",
-                "--recursive",
-                "--quiet",
-            ]
-        )
+    subprocess.run(
+        [
+            "aws",
+            "s3",
+            "cp",
+            distdir,
+            f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{distdir}",
+            "--recursive",
+        ],
+        check=True,
+        # capture_output=True,
     )
-    subprocess.check_call(
-        (
-            [
-                "aws",
-                "s3",
-                "cp",
-                newindex,
-                f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{identifier}-rapid.html",
-                "--quiet",
-            ]
-        )
+    subprocess.run(
+        [
+            "aws",
+            "s3",
+            "cp",
+            newindex,
+            f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{identifier}-rapid.html",
+        ],
+        check=True,
+        # capture_output=True,
     )
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added the scripts/aws_deploy.py script which will run at the end of
github builds and push stuff up to s3, so that you can easily get builds
to reviewers or anyone else without issue.

Needs to have some secrets set up on github to work, documentation is at
the top of the python script.

Of note, currently the --quiet flag is passed to the aws commands, resulting in a less spammy view in the actions log, but, there's three options I considered, and I'm laying them out below:

Full spam (not recommended, showing partial upload info) is here: https://github.com/vanreece/RapiD/runs/2741023491?check_suite_focus=true
![image](https://user-images.githubusercontent.com/1225959/121062522-03e1cf80-c77a-11eb-9db2-9be887ab3d96.png)

--no-progress still shows each file uploaded, but not partial progress: https://github.com/vanreece/RapiD/runs/2766195986?check_suite_focus=true
![image](https://user-images.githubusercontent.com/1225959/121062570-165c0900-c77a-11eb-8c65-5c0c2afdce56.png)

--quiet doesn't talk at all about individually uploaded files, minimum log spam (current setting): https://github.com/vanreece/RapiD/runs/2766275985?check_suite_focus=true
![image](https://user-images.githubusercontent.com/1225959/121062629-2aa00600-c77a-11eb-977f-f54cea1dcac3.png)

What do y'all think about those three options?