### PR TITLE
Add `datasets=` url parameter to specify which datasets are enabled

### DIFF
--- a/API.md
+++ b/API.md
@@ -5,7 +5,7 @@ This file documents efforts toward establishing a public API for iD.
 ##### iD Standalone
 
 iD supports several URL parameters. When constructing a URL to a standalone instance
-of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters are available
+of iD (e.g. `https://mapwith.ai/rapid`), the following parameters are available
 **in the hash portion of the URL**:
 
 * __`background`__ - The value from a `sourcetag` property in iD's
@@ -17,6 +17,8 @@ of iD (e.g. `https://ideditor-release.netlify.app`), the following parameters ar
   _Example:_ `background=custom:https://{switch:a,b,c}.tile.openstreetmap.org/{zoom}/{x}/{y}.png`
 * __`comment`__ - Prefills the changeset comment. Pass a url encoded string.<br/>
   _Example:_ `comment=CAR%20crisis%2C%20refugee%20areas%20in%20Cameroon`
+* __`datasets`__ - **RapiD Only:** A comma-separated list of dataset IDs to enable<br/>
+  _Example:_ `datasets=fbRoads,msBuildings,e75b56f13b404d7d8b47ef8be1c619ec`
 * __`disable_features`__ - Disables features in the list.<br/>
   _Example:_ `disable_features=water,service_roads,points,paths,boundaries`<br/>
   _Available features:_ `points`, `traffic_roads`, `service_roads`, `paths`, `buildings`, `building_parts`, `indoor`, `landuse`,

--- a/modules/ui/rapid_feature_toggle_dialog.js
+++ b/modules/ui/rapid_feature_toggle_dialog.js
@@ -9,6 +9,8 @@ import { svgIcon } from '../svg/icon';
 import { uiModal } from './modal';
 import { uiRapidColorpicker } from './rapid_colorpicker';
 import { uiRapidViewManageDatasets } from './rapid_view_manage_datasets';
+import { utilQsString, utilStringQs } from '../util';
+
 
 export function uiRapidFeatureToggleDialog(context, AIFeatureToggleKey, featureToggleKeyDispatcher) {
   const rapidContext = context.rapidContext();
@@ -25,16 +27,30 @@ export function uiRapidFeatureToggleDialog(context, AIFeatureToggleKey, featureT
   }
 
   function toggleDataset(event, d) {
-    const dataset = rapidContext.datasets()[d.id];
+    let datasets = rapidContext.datasets();
+    let dataset = datasets[d.id];
     if (dataset) {
       dataset.enabled = !dataset.enabled;
+
+      // update url hash
+      let hash = utilStringQs(window.location.hash);
+      hash.datasets = Object.values(datasets)
+        .filter(ds => ds.added && ds.enabled)
+        .map(ds => ds.id)
+        .join(',');
+
+      if (!window.mocha) {
+        window.location.replace('#' + utilQsString(hash, true));  // update hash
+      }
+
       context.enter(modeBrowse(context));   // return to browse mode (in case something was selected)
       context.map().pan([0,0]);             // trigger a map redraw
     }
   }
 
   function changeColor(datasetID, color) {
-    const dataset = rapidContext.datasets()[datasetID];
+    let datasets = rapidContext.datasets();
+    let dataset = datasets[datasetID];
     if (dataset) {
       dataset.color = color;
       context.map().pan([0,0]);   // trigger a map redraw

--- a/modules/ui/rapid_view_manage_datasets.js
+++ b/modules/ui/rapid_view_manage_datasets.js
@@ -9,7 +9,7 @@ import { modeBrowse } from '../modes';
 import { services } from '../services';
 import { svgIcon } from '../svg/icon';
 import { uiCombobox} from './combobox';
-import { utilKeybinding, utilNoAuto, utilRebind } from '../util';
+import { utilKeybinding, utilNoAuto, utilQsString, utilRebind, utilStringQs } from '../util';
 
 
 export function uiRapidViewManageDatasets(context, parentModal) {
@@ -439,8 +439,8 @@ export function uiRapidViewManageDatasets(context, parentModal) {
         service.loadLayer(d.id);
       }
 
-      const isBeta = d.groupCategories.some(d => d.toLowerCase() === '/categories/preview');
-      const isBuildings = d.groupCategories.some(d => d.toLowerCase() === '/categories/buildings');
+      const isBeta = d.groupCategories.some(cat => cat.toLowerCase() === '/categories/preview');
+      const isBuildings = d.groupCategories.some(cat => cat.toLowerCase() === '/categories/buildings');
 
       // pick a new color
       const colors = rapidContext.colors();
@@ -474,6 +474,17 @@ export function uiRapidViewManageDatasets(context, parentModal) {
       }
 
       datasets[d.id] = dataset;
+    }
+
+    // update url hash
+    let hash = utilStringQs(window.location.hash);
+    hash.datasets = Object.values(datasets)
+      .filter(ds => ds.added && ds.enabled)
+      .map(ds => ds.id)
+      .join(',');
+
+    if (!window.mocha) {
+      window.location.replace('#' + utilQsString(hash, true));  // update hash
     }
 
     _content.call(renderModalContent);


### PR DESCRIPTION
We are sometimes asked if it is possible to start RapiD with certain datasets already enabled or disabled.  
This can be useful for testing, or for participating in a mapping event run through the task manager.

This PR adds support for a `&datasets=` url parameter to do this!

- If no `&datasets=` parameter is present at startup, it defaults to RapiD's "builtin" list (`&datasets=fbRoads,msBuildings`)
- An empty `&datasets=` parameter is allowed - in this case all the RapiD datasets are disabled.
- You can include valid Esri ArcGIS dataset ids in this list, and it will warm up the Esri service and fetch what it needs.
- If users enable/disable/add datasets in the user interface, the url hash will update to show which ones are enabled (can then copy or bookmark the url for later).
 
Examples: 
`&datasets=`  (no RapiD data enabled)
`&datasets=fbRoads,msBuildings` (default condition - Roads and Buildings enabled)
`&datasets=fbRoads,msBuildings,e75b56f13b404d7d8b47ef8be1c619ec` (Roads, Buildings, and Esri National Address Data)

Test:  `npm run quickstart`, and test it locally:
http://127.0.0.1:8080/#background=Bing&datasets=fbRoads,msBuildings,e75b56f13b404d7d8b47ef8be1c619ec&map=17.41/40.67598/-74.52083

TODO:  I don't store any customizations for datasets, for example the color the user has chosen.  Maybe someday! 🎨 

 👀  @vanreece @Bonkles 

