### PR TITLE
Break deploy into it's own CD step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,13 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: build
+name: Build
 
-on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+on: pull_request
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
 
     strategy:
@@ -26,12 +23,3 @@ jobs:
     - run: npm install
     - run: npm run all
     - run: npm run test
-    - run: npm run aws_deploy
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: us-west-2
-        RAPID_S3_BUCKET_NAME: world.ai.rapid
-        RAPID_WEB_ROOT: https://mapwith.ai
-        NODE_VERSION: ${{ matrix.node-version }}
-      if: ${{ matrix.node-version == '16.x' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,26 +32,18 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    # - name: Configure AWS credentials
-    #   uses: aws-actions/configure-aws-credentials@v1
-    #   with:
-    #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #     aws-region: us-west-2
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
 
     - name: Setup vars
       id: vars
       run: |
         echo ::set-output name=identifier::$(git rev-parse --short ${{ github.sha }})-16.x
         echo ::set-output name=distdir::$(git rev-parse --short ${{ github.sha }})-16.x-dist
-
-    - name: TEST
-      run: |
-        echo $IDENTIFIER
-        echo $DISTDIR
-      env:
-        IDENTIFIER: ${{ steps.vars.outputs.identifier }}
-        DISTDIR: ${{ steps.vars.outputs.DISTDIR }}
 
     - name: Prep files
       run: npm run aws_deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Deploy
+
+on:
+  push:
+    branches: [ main, develop, 286-separate_cd ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Use Node.js 16.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 16.x
+    - run: npm install
+    - run: npm run all
+    - run: npm run test
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    # - name: Configure AWS credentials
+    #   uses: aws-actions/configure-aws-credentials@v1
+    #   with:
+    #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #     aws-region: us-west-2
+
+    - name: Setup vars
+      id: vars
+      run: |
+        echo ::set-output name=identifier::$(git rev-parse --short ${{ github.sha }})-16.x
+        echo ::set-output name=distdir::$(git rev-parse --short ${{ github.sha }})-16.x-dist
+
+    - name: TEST
+      run: |
+        echo $IDENTIFIER
+        echo $DISTDIR
+      env:
+        IDENTIFIER: ${{ steps.vars.outputs.identifier }}
+        DISTDIR: ${{ steps.vars.outputs.DISTDIR }}
+
+    - name: Prep files
+      run: npm run aws_deploy
+      env:
+        IDENTIFIER: ${{ steps.vars.outputs.identifier }}
+        DISTDIR: ${{ steps.vars.outputs.DISTDIR }}
+
+    - name: Copy new index file to S3
+      run: aws s3 cp $DISTDIR/index.html s3://world.ai.rapid/rapid/$IDENTIFIER-rapid.html --no-progress
+      env:
+        IDENTIFIER: ${{ steps.vars.outputs.identifier }}
+        DISTDIR: ${{ steps.vars.outputs.DISTDIR }}
+
+    - name: Copy new dist dir to S3
+      run: aws s3 cp $DISTDIR s3://world.ai.rapid/$DISTDIR --recursive --no-progress
+      env:
+        IDENTIFIER: ${{ steps.vars.outputs.identifier }}
+        DISTDIR: ${{ steps.vars.outputs.DISTDIR }}
+      # run: echo "Your build is here: https://mapwith.ai/rapid/${GITHUB_SHA::8}-16.x-dist/index.html"

--- a/scripts/aws_deploy.py
+++ b/scripts/aws_deploy.py
@@ -26,14 +26,14 @@ def deploy():
     )
     hash = output.stdout.decode("utf-8").strip()
     print("\ngithash: " + hash)
-    identifier = f"{hash}-{os.environ['NODE_VERSION']}"
-    distdir = identifier + "-dist"
+    identifier = os.environ["IDENTIFIER"]
+    distdir = os.environ["DISTDIR"]
     print("\ndistdir: " + distdir)
     # Blow away the previous dir, if any.
     if os.path.exists(distdir):
         print(f"Previous distribution dir {distdir} found, removing.")
         shutil.rmtree(distdir)
-    print("\nCreating dist folder")
+    print(f"\nCreating dist folder {distdir}")
     try:
         os.mkdir(distdir)
     except OSError as err:
@@ -67,41 +67,41 @@ def deploy():
                 )
                 output.write(s)
     print("\nCopying new index file to s3.")
-    results = subprocess.run(
-        [
-            "aws",
-            "s3",
-            "cp",
-            newindex,
-            f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{identifier}-rapid.html",
-            "--no-progress"
-        ],
-        capture_output=True,
-    )
-    if results.returncode != 0:
-        print("Got an error:")
-        print(f"STDOUT:\n{results.stdout.decode('utf-8')}")
-        print(f"STDERR:\n{results.stderr.decode('utf-8')}")
-        sys.exit(0)  # -1 for failure
-    print(f"\nCopying new {distdir} folder and index file to s3.")
-    subprocess.run(
-        [
-            "aws",
-            "s3",
-            "cp",
-            distdir,
-            f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{distdir}",
-            "--recursive",
-            "--no-progress",
-        ],
-        capture_output=True,
-    )
-    if results.returncode != 0:
-        print("Got an error:")
-        print(f"STDOUT:\n{results.stdout.decode('utf-8')}")
-        print(f"STDERR:\n{results.stderr.decode('utf-8')}")
-        sys.exit(-1)
-    print(f"Build deployment complete. Your build is here: {os.environ['RAPID_WEB_ROOT']}/rapid/{distdir}/index.html")
+    # results = subprocess.run(
+    #     [
+    #         "aws",
+    #         "s3",
+    #         "cp",
+    #         newindex,
+    #         f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{identifier}-rapid.html",
+    #         "--no-progress"
+    #     ],
+    #     capture_output=True,
+    # )
+    # if results.returncode != 0:
+    #     print("Got an error:")
+    #     print(f"STDOUT:\n{results.stdout.decode('utf-8')}")
+    #     print(f"STDERR:\n{results.stderr.decode('utf-8')}")
+    #     sys.exit(0)  # -1 for failure
+    # print(f"\nCopying new {distdir} folder and index file to s3.")
+    # subprocess.run(
+    #     [
+    #         "aws",
+    #         "s3",
+    #         "cp",
+    #         distdir,
+    #         f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{distdir}",
+    #         "--recursive",
+    #         "--no-progress",
+    #     ],
+    #     capture_output=True,
+    # )
+    # if results.returncode != 0:
+    #     print("Got an error:")
+    #     print(f"STDOUT:\n{results.stdout.decode('utf-8')}")
+    #     print(f"STDERR:\n{results.stderr.decode('utf-8')}")
+    #     sys.exit(-1)
+    # print(f"Build deployment complete. Your build is here: {os.environ['RAPID_WEB_ROOT']}/rapid/{distdir}/index.html")
 
 if __name__ == "__main__":
     deploy()

--- a/scripts/aws_deploy.py
+++ b/scripts/aws_deploy.py
@@ -66,42 +66,6 @@ def deploy():
                     .replace("'iD.legacy.js'", f"'/rapid/{distdir}/iD.legacy.js'")
                 )
                 output.write(s)
-    print("\nCopying new index file to s3.")
-    # results = subprocess.run(
-    #     [
-    #         "aws",
-    #         "s3",
-    #         "cp",
-    #         newindex,
-    #         f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{identifier}-rapid.html",
-    #         "--no-progress"
-    #     ],
-    #     capture_output=True,
-    # )
-    # if results.returncode != 0:
-    #     print("Got an error:")
-    #     print(f"STDOUT:\n{results.stdout.decode('utf-8')}")
-    #     print(f"STDERR:\n{results.stderr.decode('utf-8')}")
-    #     sys.exit(0)  # -1 for failure
-    # print(f"\nCopying new {distdir} folder and index file to s3.")
-    # subprocess.run(
-    #     [
-    #         "aws",
-    #         "s3",
-    #         "cp",
-    #         distdir,
-    #         f"s3://{os.environ['RAPID_S3_BUCKET_NAME']}/rapid/{distdir}",
-    #         "--recursive",
-    #         "--no-progress",
-    #     ],
-    #     capture_output=True,
-    # )
-    # if results.returncode != 0:
-    #     print("Got an error:")
-    #     print(f"STDOUT:\n{results.stdout.decode('utf-8')}")
-    #     print(f"STDERR:\n{results.stderr.decode('utf-8')}")
-    #     sys.exit(-1)
-    # print(f"Build deployment complete. Your build is here: {os.environ['RAPID_WEB_ROOT']}/rapid/{distdir}/index.html")
 
 if __name__ == "__main__":
     deploy()


### PR DESCRIPTION
This PR breaks the deploy process into its own step and slightly changes the tooling used for deployment. The overall process is the same but now we use other actions to configure aws credentials.

This also changes when each workflow would run. 
`Build` will run on any PR on any branch
`Deploy` will only run on push to certain branches right now. I plan to update this in a follow up for #285 

Closes #286 