### PR TITLE
Add regex to deploy "staging" branches on push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: Deploy
 
 on:
   push:
-    branches: [ main, develop, 286-separate_cd ]
+    branches: [ main, develop, '*staging*' ]
 
 jobs:
   build:


### PR DESCRIPTION
With this change, any branch with `staging` in the name will make a new deployment with it's commit hash just as usual. The branches can just be something like `footway_staging` or `staging/footway_workflow`. Either should work, I'll leave it up to ya'll to decide which style is your preference 😄 

Closes #285 