### PR TITLE
Ensure 'building=yes' gets overwritten with 'building=*' instead of merged

### DIFF
--- a/modules/osm/entity.js
+++ b/modules/osm/entity.js
@@ -147,6 +147,13 @@ osmEntity.prototype = {
             if (!t1) {
                 changed = true;
                 merged[k] = t2;
+            } else if (k === 'building') {
+                if (t2 === 'yes') {
+                    continue;
+                } else if (t1 === 'yes') {
+                    changed = true;
+                    merged[k] = t2;
+                }
             } else if (t1 !== t2) {
                 changed = true;
                 merged[k] = utilUnicodeCharsTruncated(

--- a/test/spec/osm/entity.js
+++ b/test/spec/osm/entity.js
@@ -164,6 +164,26 @@ describe('iD.osmEntity', function () {
             expect(a.mergeTags(b.tags).tags).to.eql({a: 'a;b'});
             expect(b.mergeTags(a.tags).tags).to.eql({a: 'b;a'});
         });
+
+        it('does NOT combine building tags for new tag: building=yes', function () {
+            var a = iD.osmEntity({tags: {building: 'residential'}});
+            var b = a.mergeTags({building: 'yes'});
+            expect(b.tags).to.eql({building: 'residential'});
+        });
+
+        it('does combine building tags if existing tag is building=yes', function () {
+            var a = iD.osmEntity({tags: {building: 'yes'}});
+            var b = a.mergeTags({building: 'residential'});
+            expect(b.tags).to.eql({building: 'residential'});
+        });
+
+        it('keeps the existing building tag if the new tag is not building=yes', function () {
+            var a = iD.osmEntity({tags: {building: 'residential'}});
+            var b = a.mergeTags({building: 'house'});
+            expect(b.tags).to.eql({building: 'residential'});
+        });
+
+
     });
 
     describe('#osmId', function () {


### PR DESCRIPTION
This code change introduces several bits of logic to help avoid costly human edits after merging address datasets to the map. 

Merge tags will continue to work as it always has, except in the following cases. 

 The entity being merged to is a building, in which case:
   * if the building's tag is simply 'yes', replace it with the incoming value. 
   * Otherwise, leave it alone. 

See the associated bug for more info on how to repro. 

After this code change, I was able to verify that the same case outlined in the bug report now results in the correct behavior- original tag is kept. 

Before code change - merged `building` tag with multiple values:
![Screen Shot 2021-11-12 at 12 05 34 PM](https://user-images.githubusercontent.com/1887955/141509613-fa11dc37-23c6-4217-ae81-881b28228492.png)

After code change: unmerged building tag keeping original value: 
![Screen Shot 2021-11-12 at 12 06 10 PM](https://user-images.githubusercontent.com/1887955/141509679-b9547cae-6663-4b1f-bd1f-c5caa9b6ed16.png)

