### PR TITLE
Google Buildings- fix warning about Google Africa Buildings dataset

### DIFF
--- a/modules/validations/incompatible_source.js
+++ b/modules/validations/incompatible_source.js
@@ -17,7 +17,7 @@ export function validationIncompatibleSource() {
     {
       id: 'google',
       regex: /google/i,
-      exceptRegex: /((books|drive)\.google|google\s?(books|drive|plus))/i
+      exceptRegex: /((books|drive)\.google|google\s?(books|drive|plus))|(esri\/Google_Africa_Buildings)/i
     }
   ];
 

--- a/test/spec/validations/incompatible_source.js
+++ b/test/spec/validations/incompatible_source.js
@@ -63,4 +63,9 @@ describe('iD.validations.incompatible_source', function () {
         expect(issue.entityIds[0]).to.eql('w-1');
     });
 
+    it('does not flag buildings in the google-africa-buildings dataset', function() {
+        createWay({ building: 'yes', source: 'esri/Google_Africa_Buildings' });
+        var issues = validate();
+        expect(issues).to.have.lengthOf(0);
+    });
 });


### PR DESCRIPTION
We have a boilerplate validator warning that tries to provide a strong hint to users that google data sources are proprietary and not valid for mapping. 

In this case, though, the esri-hosted Google Africa Buildings dataset is completely okay for mapping. 

Prior to adding this fix, here's what a user would see: 
![image](https://user-images.githubusercontent.com/1887955/145443216-85d37789-5be4-4443-8a94-215d3e02d621.png)


After adding this new regex exception and adding a building, the validation has gone away. 

![image](https://user-images.githubusercontent.com/1887955/145442939-69d0a509-5c17-4288-97a4-80abec11bcb3.png)
