### PR TITLE
Readme: Add link to editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ RapiD is an extension of the [iD editor](https://github.com/openstreetmap/iD) fo
 
 For basic information about the iD editor (architecture, build and installation instructions, etc.), please refer to the [iD github repo](https://github.com/openstreetmap/iD). RapiD shares the same building and installation process as iD.
 
+## Start mapping
+
+* Use [mapwith.ai/rapid](https://mapwith.ai/rapid#background=Maxar-FB&disable_features=boundaries&map=16/2.248562199999995/32.873861600000055) for the current release.
+* Learn more at [mapwith.ai](https://mapwith.ai/).
+
 ## Participate!
 
 * Read the project [Code of Conduct](CODE_OF_CONDUCT.md) and [Contributing Guide](CONTRIBUTING.md) to learn about how to contribute.


### PR DESCRIPTION
I was searching for a link to the editor in the readme … so here is one.

What would a good link for the repo-link (below the description) be? Right into the editor or to mapwithai?

And is there a standard list of staging/pre-release deployments, that could be listed as well? https://twitter.com/bhousel/status/1510053767802077185 sounds like an URL that will be merged and removed again some time soon.