### PR TITLE
Aws roles

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,8 +55,6 @@ jobs:
     - name: Configure AWS credentials 🔐
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        # aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        # aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         role-to-assume: ${{ secrets.AWS_RAPID_DEPLOY_ROLE_ARN }}
         role-duration-seconds: 900 # the ttl of the session, in seconds.
         aws-region: us-west-2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Run 🏃
       run: npm run all
 
-    # - name: Test 🧪
-    #   run: npm run test
+    - name: Test 🧪
+      run: npm run test
 
     - name: Upload artifacts 📤
       uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: Deploy
 
 on:
   push:
-    branches: [ main, develop, '*staging*' ]
+    branches: [ main, develop, '*staging*', aws_roles ]
 
 jobs:
   build:
@@ -55,8 +55,10 @@ jobs:
     - name: Configure AWS credentials 🔐
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        # aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        # aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.AWS_RAPID_DEPLOY_ROLE_ARN}}
+        role-duration-seconds: 900 # the ttl of the session, in seconds.
         aws-region: us-west-2
 
     - name: Setup vars 📋

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: Deploy
 
 on:
   push:
-    branches: [ main, develop, '*staging*', aws_roles ]
+    branches: [ main, develop, '*staging*' ]
 
 permissions:
   id-token: write # required to use OIDC authentication

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
       with:
         # aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         # aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        role-to-assume: ${{ secrets.AWS_RAPID_DEPLOY_ROLE_ARN}}
+        role-to-assume: ${{ secrets.AWS_RAPID_DEPLOY_ROLE_ARN }}
         role-duration-seconds: 900 # the ttl of the session, in seconds.
         aws-region: us-west-2
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [ main, develop, '*staging*', aws_roles ]
 
+permissions:
+  id-token: write # required to use OIDC authentication
+  contents: read # required to checkout the code from the repo
+
 jobs:
   build:
     name: Build
@@ -27,8 +31,8 @@ jobs:
     - name: Run 🏃
       run: npm run all
 
-    - name: Test 🧪
-      run: npm run test
+    # - name: Test 🧪
+    #   run: npm run test
 
     - name: Upload artifacts 📤
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
This PR enables OIDC auth for our github actions, allowing us to get out of the 'permanent secret key/id' security no-no that we've been using since last august. 

Now, each time we do a deploy, we tell the action to assume a certain role (the ARN of which is stored in a repo secret) that grants us access to the AWS infra we need to do the upload. 


Outside the scope of this PR: The new Identity Provider and Role that I set up in our AWS account to support OIDC.  It's enough to know that the new Role has been set up with its ARN stored in a repo secret, which our deploy .yaml reads. 

Here's the trust policy for that new role titled `rapid-cicd-role` that I created in the fbjagill account: 

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "arn:aws:iam::632571768781:oidc-provider/token.actions.githubusercontent.com"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
                },
                "StringLike": {
                    "token.actions.githubusercontent.com:sub": "repo:facebookincubator/RapiD:*"
                }
            }
        }
    ]
}
```
}

This is fairly standard boilerplate for any such ephemeral cred service config in github actions- note though that the second 'stringLike' condition predicates only our repository- actions from other repos can't use this to deploy stuff to our bucket. 

> 
Note: The old secrets are still part of the repo (for now) so as not to break any existing builds/deploys on other branches. But, once this is merged into main those keys should be deleted forever. 



Further reading: 

https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services

https://benoitboure.com/securely-access-your-aws-resources-from-github-actions